### PR TITLE
Fix tool calls on gateway

### DIFF
--- a/src/ai/models/ai_gateway/stream.py
+++ b/src/ai/models/ai_gateway/stream.py
@@ -158,9 +158,16 @@ async def _build_request_body(
 # ---------------------------------------------------------------------------
 
 
-def _expand_tool_call(data: dict[str, Any]) -> list[events_.Event]:
-    """Expand a complete ``tool-call`` part into Start + Delta + End."""
+def _expand_tool_call(
+    data: dict[str, Any], streamed_tool_ids: set[str]
+) -> list[events_.Event]:
+    """Expand a complete ``tool-call`` part into Start + Delta + End.
+
+    Returns empty when the tool was already streamed via ``tool-input-*``.
+    """
     tc_id = data.get("toolCallId", "")
+    if tc_id in streamed_tool_ids:
+        return []
     tool_name = data.get("toolName", "")
     tool_input = data.get("input", "")
     args_str = tool_input if isinstance(tool_input, str) else json.dumps(tool_input)
@@ -198,7 +205,9 @@ def _parse_usage(data: Any) -> usage_.Usage:
     )
 
 
-def _parse_stream_part(data: dict[str, Any]) -> list[events_.Event]:
+def _parse_stream_part(
+    data: dict[str, Any], streamed_tool_ids: set[str]
+) -> list[events_.Event]:
     """Convert a ``LanguageModelV3StreamPart`` to public events."""
     match data.get("type", ""):
         case "text-start":
@@ -230,9 +239,11 @@ def _parse_stream_part(data: dict[str, Any]) -> list[events_.Event]:
             return [events_.ReasoningEnd(block_id=data.get("id", "reasoning"))]
 
         case "tool-input-start":
+            tcid = data.get("id", "")
+            streamed_tool_ids.add(tcid)
             return [
                 events_.ToolStart(
-                    tool_call_id=data.get("id", ""),
+                    tool_call_id=tcid,
                     tool_name=data.get("toolName", ""),
                 )
             ]
@@ -249,7 +260,7 @@ def _parse_stream_part(data: dict[str, Any]) -> list[events_.Event]:
             return [events_.ToolEnd(tool_call_id=data.get("id", ""))]
 
         case "tool-call":
-            return _expand_tool_call(data)
+            return _expand_tool_call(data, streamed_tool_ids)
 
         case "file":
             return [
@@ -313,8 +324,9 @@ async def stream(
                 )
 
             yield events_.StreamStart()
+            streamed_tool_ids: set[str] = set()
             async for data in _common.parse_sse_lines(response):
-                for event in _parse_stream_part(data):
+                for event in _parse_stream_part(data, streamed_tool_ids):
                     yield event
     except errors.GatewayError:
         raise

--- a/src/ai/models/core/api.py
+++ b/src/ai/models/core/api.py
@@ -67,7 +67,6 @@ class Stream:
         self._gen = gen
         self._message: types.Message = types.Message(role="assistant", parts=[])
         self._parts: dict[str, types.Part] = {}
-        self._finished_tools: set[str] = set()
 
     async def __aenter__(self) -> Self:
         return self
@@ -138,22 +137,18 @@ class Stream:
                 ):
                     existing_reasoning.signature = sig
             case types.ToolStart(tool_call_id=tcid, tool_name=name):
-                if tcid not in self._parts:
-                    tcp = types.ToolCallPart(
-                        id=tcid,
-                        tool_call_id=tcid,
-                        tool_name=name,
-                        tool_args="",
-                    )
-                    self._message.parts.append(tcp)
-                    self._parts[tcid] = tcp
+                tcp = types.ToolCallPart(
+                    id=tcid,
+                    tool_call_id=tcid,
+                    tool_name=name,
+                    tool_args="",
+                )
+                self._message.parts.append(tcp)
+                self._parts[tcid] = tcp
             case types.ToolDelta(tool_call_id=tcid, chunk=c):
-                if tcid not in self._finished_tools:
-                    existing_tool = self._parts.get(tcid)
-                    if isinstance(existing_tool, types.ToolCallPart):
-                        existing_tool.tool_args += c
-            case types.ToolEnd(tool_call_id=tcid):
-                self._finished_tools.add(tcid)
+                existing_tool = self._parts.get(tcid)
+                if isinstance(existing_tool, types.ToolCallPart):
+                    existing_tool.tool_args += c
             case types.FileEvent(block_id=bid, media_type=mt, data=d, filename=fname):
                 fp = types.FilePart(
                     id=bid or types.generate_id(),

--- a/src/ai/models/core/api.py
+++ b/src/ai/models/core/api.py
@@ -67,6 +67,7 @@ class Stream:
         self._gen = gen
         self._message: types.Message = types.Message(role="assistant", parts=[])
         self._parts: dict[str, types.Part] = {}
+        self._finished_tools: set[str] = set()
 
     async def __aenter__(self) -> Self:
         return self
@@ -137,18 +138,22 @@ class Stream:
                 ):
                     existing_reasoning.signature = sig
             case types.ToolStart(tool_call_id=tcid, tool_name=name):
-                tcp = types.ToolCallPart(
-                    id=tcid,
-                    tool_call_id=tcid,
-                    tool_name=name,
-                    tool_args="",
-                )
-                self._message.parts.append(tcp)
-                self._parts[tcid] = tcp
+                if tcid not in self._parts:
+                    tcp = types.ToolCallPart(
+                        id=tcid,
+                        tool_call_id=tcid,
+                        tool_name=name,
+                        tool_args="",
+                    )
+                    self._message.parts.append(tcp)
+                    self._parts[tcid] = tcp
             case types.ToolDelta(tool_call_id=tcid, chunk=c):
-                existing_tool = self._parts.get(tcid)
-                if isinstance(existing_tool, types.ToolCallPart):
-                    existing_tool.tool_args += c
+                if tcid not in self._finished_tools:
+                    existing_tool = self._parts.get(tcid)
+                    if isinstance(existing_tool, types.ToolCallPart):
+                        existing_tool.tool_args += c
+            case types.ToolEnd(tool_call_id=tcid):
+                self._finished_tools.add(tcid)
             case types.FileEvent(block_id=bid, media_type=mt, data=d, filename=fname):
                 fp = types.FilePart(
                     id=bid or types.generate_id(),

--- a/tests/models/ai_gateway/test_protocol.py
+++ b/tests/models/ai_gateway/test_protocol.py
@@ -235,7 +235,7 @@ class TestParseStreamPartComplex:
     def test_text_delta_uses_textDelta_key(self) -> None:
         """The gateway sends ``textDelta`` (camelCase), not ``delta``."""
         events = stream_mod._parse_stream_part(
-            {"type": "text-delta", "id": "t1", "textDelta": "Hello"}
+            {"type": "text-delta", "id": "t1", "textDelta": "Hello"}, set()
         )
         assert isinstance(events[0], events_.TextDelta)
         assert events[0].chunk == "Hello"
@@ -249,7 +249,8 @@ class TestParseStreamPartComplex:
                 "toolCallId": "tc-1",
                 "toolName": "get_weather",
                 "input": {"city": "SF"},
-            }
+            },
+            set(),
         )
         assert len(events) == 3
         assert isinstance(events[0], events_.ToolStart)
@@ -257,6 +258,24 @@ class TestParseStreamPartComplex:
         assert isinstance(events[1], events_.ToolDelta)
         assert json.loads(events[1].chunk) == {"city": "SF"}
         assert isinstance(events[2], events_.ToolEnd)
+
+    def test_tool_call_skipped_when_already_streamed(self) -> None:
+        """A ``tool-call`` that duplicates a streamed tool is dropped."""
+        seen: set[str] = set()
+        stream_mod._parse_stream_part(
+            {"type": "tool-input-start", "id": "tc-1", "toolName": "get_weather"},
+            seen,
+        )
+        events = stream_mod._parse_stream_part(
+            {
+                "type": "tool-call",
+                "toolCallId": "tc-1",
+                "toolName": "get_weather",
+                "input": {"city": "SF"},
+            },
+            seen,
+        )
+        assert events == []
 
     def test_finish_flat_usage(self) -> None:
         events = stream_mod._parse_stream_part(
@@ -267,7 +286,8 @@ class TestParseStreamPartComplex:
                     "prompt_tokens": 10,
                     "completion_tokens": 20,
                 },
-            }
+            },
+            set(),
         )
         done = events[0]
         assert isinstance(done, events_.StreamEnd)
@@ -293,7 +313,8 @@ class TestParseStreamPartComplex:
                         "reasoning": 30,
                     },
                 },
-            }
+            },
+            set(),
         )
         done = events[0]
         assert isinstance(done, events_.StreamEnd)
@@ -311,7 +332,8 @@ class TestParseStreamPartComplex:
                 "id": "f1",
                 "mediaType": "image/png",
                 "data": "iVBORw0KGgo=",
-            }
+            },
+            set(),
         )
         assert len(events) == 1
         assert isinstance(events[0], events_.FileEvent)
@@ -321,14 +343,16 @@ class TestParseStreamPartComplex:
 
     def test_file_part_defaults(self) -> None:
         """A minimal ``file`` part uses sensible defaults."""
-        events = stream_mod._parse_stream_part({"type": "file", "data": "somedata"})
+        events = stream_mod._parse_stream_part(
+            {"type": "file", "data": "somedata"}, set()
+        )
         assert len(events) == 1
         assert isinstance(events[0], events_.FileEvent)
         assert events[0].media_type == "application/octet-stream"
 
     def test_unknown_types_produce_no_events(self) -> None:
         for t in ("stream-start", "raw", "response-metadata", "banana"):
-            assert stream_mod._parse_stream_part({"type": t}) == []
+            assert stream_mod._parse_stream_part({"type": t}, set()) == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Gateway will both stream a tool call and provide a full tool-call
event after, which leads to duplicate tool calls in the stream, which
then blow up in the validator.

This duplication in the stream existed previously, but changes in how
the stream is assembled in #55 cause it to break tool calling in the
agent (no longer using an id-keyed dict to build up the parts).

This diff is basically pure-agentic debugging, but I had a isomorphic
change in my WIP agent branch, done at the gateway streaming layer.
