### PR TITLE
Make the fastapi-vite example work and add an e2e-test

### DIFF
--- a/examples/fastapi-vite/backend/agent.py
+++ b/examples/fastapi-vite/backend/agent.py
@@ -34,12 +34,26 @@ async def graph(context: ai.Context) -> AsyncGenerator[ai.AgentEvent]:
     Reject buttons and sends the decision back on the next request.
     """
     while True:
-        s = ai.models.stream(context.model, context.messages, tools=context.tools)
-        async for event in s:
-            yield event
-        context.add(s.message)
+        # If the last message is already an assistant turn, we're being
+        # replayed after a hook resolution — skip the model call and go
+        # straight to processing its tool calls (resolutions are
+        # pre-registered, so the hook returns immediately).
+        if context.keep_running():
+            s = ai.models.stream(context.model, context.messages, tools=context.tools)
+            async for event in s:
+                yield event
+            context.add(s.message)
 
-        tool_calls = context.resolve(s.tool_calls)
+        # Pull tool calls off the most recent assistant message.
+        # ``to_messages`` may append "internal" hook messages after the
+        # assistant, so ``messages[-1]`` isn't always the assistant turn.
+        last_assistant = next(
+            (m for m in reversed(context.messages) if m.role == "assistant"),
+            None,
+        )
+        tool_calls = (
+            context.resolve(last_assistant.tool_calls) if last_assistant else []
+        )
         if not tool_calls:
             return
 
@@ -47,6 +61,7 @@ async def graph(context: ai.Context) -> AsyncGenerator[ai.AgentEvent]:
             *(_execute_with_approval(tc) for tc in tool_calls)
         )
         yield ai.tool_result(*results)
+        context.add(ai.tool_message(*results))
 
 
 async def _execute_with_approval(tc: ai.ToolCall) -> ai.ToolCallResult:

--- a/examples/fastapi-vite/e2e-test/e2e-test.mjs
+++ b/examples/fastapi-vite/e2e-test/e2e-test.mjs
@@ -1,0 +1,87 @@
+// End-to-end smoke test for the chat + tool-approval flow.
+//
+// Drives the Vite frontend in a headless browser, sends a message that
+// triggers the `talk_to_mothership` tool, approves the request, and
+// asserts the tool result is rendered.
+//
+// Prereqs:
+//   - backend running on :8000 (cd backend && uv run --frozen --with-editable ~/src/py-ai/ fastapi dev main.py)
+//   - frontend running on :5173 (cd frontend && pnpm dev)
+//   - install deps:  npm install && npx playwright install chromium
+//
+// Run from this directory:  node e2e-test.mjs
+
+import { chromium } from "playwright";
+
+const FRONTEND = process.env.FRONTEND_URL ?? "http://localhost:5173/";
+const PROMPT = "Ask the mothership when robots will take over";
+
+const browser = await chromium.launch();
+const ctx = await browser.newContext();
+const page = await ctx.newPage();
+
+const requests = [];
+const responses = [];
+page.on("request", (req) => {
+  if (req.url().includes("/chat")) {
+    requests.push({ method: req.method(), url: req.url(), body: req.postData() });
+  }
+});
+page.on("response", async (resp) => {
+  if (resp.url().includes("/chat")) {
+    try {
+      responses.push({ status: resp.status(), body: await resp.text() });
+    } catch {}
+  }
+});
+page.on("pageerror", (err) => console.error("[pageerror]", err.message));
+
+await page.goto(FRONTEND);
+await page.waitForLoadState("networkidle");
+
+await page.getByPlaceholder("Ask me anything...").fill(PROMPT);
+await page.keyboard.press("Enter");
+
+// Tool collapsible appears once the approval-request event arrives.
+const toolToggle = page.getByRole("button", { name: /talk_to_mothership/ });
+await toolToggle.waitFor({ state: "visible", timeout: 30000 });
+await toolToggle.click();
+
+const approveBtn = page.getByRole("button", { name: "Approve" });
+await approveBtn.waitFor({ state: "visible", timeout: 10000 });
+await approveBtn.click();
+
+// Wait for the assistant's final reply to render. The Mothership tool
+// returns "Soon." so the model usually echoes that back.
+try {
+  await page.getByText(/Soon\./i).waitFor({ state: "visible", timeout: 30000 });
+} catch (e) {
+  console.error("\n=== TIMEOUT — dumping diagnostics ===");
+  console.error("REQUEST COUNT:", requests.length);
+  if (requests.length >= 2) {
+    console.error("\n--- Request #2 (after approval) ---");
+    console.error(requests[1].body);
+  }
+  if (responses.length >= 2) {
+    console.error("\n--- Response #2 ---");
+    console.error(responses[1].body);
+  }
+  throw e;
+}
+
+const transcript = await page.locator("body").innerText();
+console.log("=== TRANSCRIPT ===");
+console.log(transcript);
+
+// Sanity: the tool should have transitioned out of "Awaiting Approval".
+if (transcript.includes("Awaiting Approval")) {
+  console.error("FAIL: tool still awaiting approval — replay flow is broken");
+  console.error("\n=== REQUESTS ===");
+  for (const r of requests) console.error(r.method, r.url, r.body?.slice(0, 1000));
+  console.error("\n=== RESPONSES ===");
+  for (const r of responses) console.error(r.status, r.body?.slice(0, 2000));
+  process.exit(1);
+}
+
+console.log("PASS");
+await browser.close();

--- a/examples/fastapi-vite/e2e-test/package-lock.json
+++ b/examples/fastapi-vite/e2e-test/package-lock.json
@@ -1,0 +1,60 @@
+{
+  "name": "fastapi-vite-e2e",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "fastapi-vite-e2e",
+      "devDependencies": {
+        "playwright": "^1.59.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/examples/fastapi-vite/e2e-test/package.json
+++ b/examples/fastapi-vite/e2e-test/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "fastapi-vite-e2e",
+  "private": true,
+  "scripts": {
+    "test:e2e": "node e2e-test.mjs"
+  },
+  "devDependencies": {
+    "playwright": "^1.59.1"
+  }
+}

--- a/examples/fastapi-vite/e2e-test/run.sh
+++ b/examples/fastapi-vite/e2e-test/run.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Launch backend + frontend, run the e2e test, tear everything down.
+#
+# Requires AI_GATEWAY_API_KEY in the environment.
+
+set -euo pipefail
+
+if [[ -z "${AI_GATEWAY_API_KEY:-}" ]]; then
+    echo "AI_GATEWAY_API_KEY must be set" >&2
+    exit 1
+fi
+
+HERE=$(cd "$(dirname "$0")" && pwd)
+ROOT=$(cd "$HERE/.." && pwd)
+LOGS=$(mktemp -d)
+echo "Logs: $LOGS"
+
+cleanup() {
+    [[ -n "${BACKEND_PID:-}" ]] && kill "$BACKEND_PID" 2>/dev/null || true
+    [[ -n "${FRONTEND_PID:-}" ]] && kill "$FRONTEND_PID" 2>/dev/null || true
+    wait 2>/dev/null || true
+}
+trap cleanup EXIT
+
+echo "Starting backend on :8000..."
+(
+    cd "$ROOT/backend"
+    uv run --frozen --with-editable ~/src/py-ai/ fastapi dev main.py
+) > "$LOGS/backend.log" 2>&1 &
+BACKEND_PID=$!
+
+echo "Starting frontend on :5173..."
+(
+    cd "$ROOT/frontend"
+    pnpm dev
+) > "$LOGS/frontend.log" 2>&1 &
+FRONTEND_PID=$!
+
+echo "Waiting for backend..."
+until curl -sf http://127.0.0.1:8000/health > /dev/null 2>&1; do
+    if ! kill -0 "$BACKEND_PID" 2>/dev/null; then
+        echo "Backend died — see $LOGS/backend.log" >&2
+        exit 1
+    fi
+    sleep 0.5
+done
+
+echo "Waiting for frontend..."
+until curl -sf http://127.0.0.1:5173/ > /dev/null 2>&1; do
+    if ! kill -0 "$FRONTEND_PID" 2>/dev/null; then
+        echo "Frontend died — see $LOGS/frontend.log" >&2
+        exit 1
+    fi
+    sleep 0.5
+done
+
+echo "Running e2e test..."
+cd "$HERE"
+[[ -d node_modules ]] || npm install
+node e2e-test.mjs

--- a/src/ai/agents/ui/ai_sdk/inbound.py
+++ b/src/ai/agents/ui/ai_sdk/inbound.py
@@ -218,17 +218,25 @@ def to_messages(
     if apply_approvals_:
         apply_approvals(approvals)
 
-    if approvals and messages:
-        # The assistant message that originated the approval-responded tool
-        # call would re-send the duplicate tool-use to the LLM on replay.
-        # Walk past any trailing internal (hook) messages and drop the
-        # assistant message beneath them.
-        idx = len(messages) - 1
-        while idx >= 0 and messages[idx].role == "internal":
-            idx -= 1
-        if idx >= 0 and messages[idx].role == "assistant":
-            logger.info("Stripping assistant message originating responded approvals")
-            messages = messages[:idx] + messages[idx + 1 :]
+    # TODO: Stripping the trailing assistant message broke the approval
+    # replay flow — the loop needs that message (with the original
+    # tool_call_ids) to match the pre-registered hook resolutions.
+    # Without it, the loop re-calls the LLM, gets new tool_call_ids,
+    # and the resolutions never match. Loops should instead check
+    # `context.keep_running()` and skip the model call when the last
+    # message is already an assistant turn.
+    #
+    # if approvals and messages:
+    #     # The assistant message that originated the approval-responded tool
+    #     # call would re-send the duplicate tool-use to the LLM on replay.
+    #     # Walk past any trailing internal (hook) messages and drop the
+    #     # assistant message beneath them.
+    #     idx = len(messages) - 1
+    #     while idx >= 0 and messages[idx].role == "internal":
+    #         idx -= 1
+    #     if idx >= 0 and messages[idx].role == "assistant":
+    #         logger.info("Stripping assistant message originating responded approvals")
+    #         messages = messages[:idx] + messages[idx + 1 :]
 
     return messages
 

--- a/tests/agents/ui/ai_sdk/test_inbound.py
+++ b/tests/agents/ui/ai_sdk/test_inbound.py
@@ -83,7 +83,7 @@ def test_to_messages_approval_hook_emitted_as_internal() -> None:
     assert hook.hook_id == "approve_tc1"
 
 
-def test_to_messages_strips_trailing_assistant_when_approved() -> None:
+def test_to_messages_keeps_trailing_assistant_when_approved() -> None:
     result = to_messages(
         [
             _ui("user", _text("delete it"), id="u1"),
@@ -100,7 +100,7 @@ def test_to_messages_strips_trailing_assistant_when_approved() -> None:
         ],
         apply_approvals_=False,
     )
-    assert [m.role for m in result] == ["user", "internal"]
+    assert [m.role for m in result] == ["user", "assistant", "internal"]
 
 
 def test_extract_approvals_returns_approved_responses() -> None:


### PR DESCRIPTION
e2e-test is pure vibed, of course.

The "serverless" hook stuff works now, but in a bad way (the same as
agent_hooks_serverless.py) that we will need to fix.
