### PR TITLE
Package streaming tool call results in PartialToolCallResult

### DIFF
--- a/examples/multiagent-textual/client.py
+++ b/examples/multiagent-textual/client.py
@@ -116,7 +116,6 @@ class MultiAgentApp(textual.app.App[None]):
         self._event_adapter: pydantic.TypeAdapter[ai.AgentEvent] = pydantic.TypeAdapter(
             ai.AgentEvent
         )
-        self._current_label = "unknown"
 
     def compose(self) -> textual.app.ComposeResult:
         yield AgentPanel("mothership", "mothership")
@@ -165,18 +164,23 @@ class MultiAgentApp(textual.app.App[None]):
     # ------------------------------------------------------------------
     # Event routing
     #
-    # TODO: streaming events (TextDelta, etc.) don't carry a source
-    # label, so _current_label is only updated when a ToolCallResult
-    # or HookEvent arrives.  With concurrent sub-agents, streaming
-    # text can route to the wrong panel.  The hooks in this demo
-    # serialize the flow enough that it works in practice, but a
-    # proper fix needs labels on streaming events.
+    # Sub-agent events arrive wrapped in PartialToolCallResult, which
+    # carries the branch label set by ``yield_from(..., label=...)``.
+    # We unwrap and route by that label.  Unwrapped (top-level) events
+    # come from the orchestrator's own stream — the summary agent — and
+    # are routed to the "summary" panel by default.
     # ------------------------------------------------------------------
 
     def _handle_event(self, event: ai.AgentEvent) -> None:
+        if isinstance(event, ai.PartialToolCallResult):
+            label = str(event.label) if event.label is not None else "summary"
+            inner = self._event_adapter.validate_python(event.value)
+            self._render(label, inner)
+        else:
+            self._render("summary", event)
+
+    def _render(self, label: str, event: ai.AgentEvent) -> None:
         if isinstance(event, ai.ToolCallResult):
-            label = event.message.source_label or self._current_label
-            self._current_label = label
             panel = self._get_panel(label)
             if panel is not None:
                 for part in event.message.parts:
@@ -195,14 +199,14 @@ class MultiAgentApp(textual.app.App[None]):
             return
 
         if isinstance(event, ai.TextDelta):
-            panel = self._get_panel(self._current_label)
+            panel = self._get_panel(label)
             if panel is not None:
                 panel.append_text(event.chunk)
                 if panel.status == "idle":
                     panel.status = "streaming..."
 
         elif isinstance(event, ai.ReasoningDelta | ai.ToolDelta):
-            panel = self._get_panel(self._current_label)
+            panel = self._get_panel(label)
             if panel is not None:
                 panel.append_text(event.chunk, style="dim")
 

--- a/examples/multiagent-textual/server.py
+++ b/examples/multiagent-textual/server.py
@@ -110,8 +110,9 @@ def _gated_agent(
                         )
                 else:
                     results.append(await tc())
+                yield results[-1]
 
-            yield ai.tool_result(*results)
+            context.add(ai.tool_message(*results))
 
     return gated
 
@@ -142,8 +143,8 @@ async def multiagent_loop(context: ai.Context) -> AsyncGenerator[ai.AgentEvent]:
     query = context.messages[-1].text
 
     # Fan out: both branches stream concurrently via yield_from.
-    # Messages are forwarded to the runtime automatically and labelled
-    # so the TUI can route them to the correct panel.
+    # Each yield_from wraps every inner event in a PartialToolCallResult
+    # carrying the branch label, so the TUI can route to the right panel.
     r1, r2 = await asyncio.gather(
         ai.yield_from(
             mothership_agent.run(
@@ -155,8 +156,8 @@ async def multiagent_loop(context: ai.Context) -> AsyncGenerator[ai.AgentEvent]:
                     ),
                     ai.user_message(query),
                 ],
-                label="mothership",
-            )
+            ),
+            label="mothership",
         ),
         ai.yield_from(
             data_centers_agent.run(
@@ -168,14 +169,16 @@ async def multiagent_loop(context: ai.Context) -> AsyncGenerator[ai.AgentEvent]:
                     ),
                     ai.user_message(query),
                 ],
-                label="data_centers",
-            )
+            ),
+            label="data_centers",
         ),
     )
 
     combined = f"Mothership: {r1}\nData centers: {r2}"
 
-    # Fan in: summarise via a labelled sub-agent.
+    # Fan in: stream the summary directly.  Top-level events from the
+    # orchestrator are unlabeled — the client routes them to the summary
+    # panel as its default.
     summary_agent = ai.agent()
     async for event in summary_agent.run(
         context.model,
@@ -185,7 +188,6 @@ async def multiagent_loop(context: ai.Context) -> AsyncGenerator[ai.AgentEvent]:
             ),
             ai.user_message(combined),
         ],
-        label="summary",
     ):
         yield event
 
@@ -207,6 +209,11 @@ def _normalise_event(data: dict[str, Any]) -> dict[str, Any]:
     message = data.get("message")
     if isinstance(message, dict):
         data["message"] = _normalise_message(message)
+    # Recurse into PartialToolCallResult wrappers so the inner event's
+    # message gets normalised too.
+    inner = data.get("value")
+    if isinstance(inner, dict):
+        data["value"] = _normalise_event(inner)
     return data
 
 

--- a/examples/multiagent-textual/test-e2e.py
+++ b/examples/multiagent-textual/test-e2e.py
@@ -152,7 +152,7 @@ def main() -> int:
                 "-x",
                 "80",
                 "-y",
-                "60",
+                "120",
                 (
                     f"cd '{HERE}' && "
                     "uv run --frozen --with-editable ~/src/py-ai/ "

--- a/examples/samples/agent_nested.py
+++ b/examples/samples/agent_nested.py
@@ -45,6 +45,13 @@ async def main() -> None:
     ]
 
     async for event in orchestrator.run(model, messages):
+        # Subtool results
+        if isinstance(event, ai.PartialToolCallResult):
+            if isinstance(event.value, ai.TextDelta):
+                print(event.value.chunk.upper(), end="", flush=True)
+            elif isinstance(event, ai.StreamEnd):
+                print()
+
         if isinstance(event, ai.TextDelta):
             print(event.chunk, end="", flush=True)
     print()

--- a/examples/samples/middleware_simple.py
+++ b/examples/samples/middleware_simple.py
@@ -29,15 +29,14 @@ class PrintMiddleware(ai.Middleware):
         call: ai.middleware.AgentRunContext,
         next: Callable[[ai.middleware.AgentRunContext], AsyncGenerator[Any]],
     ) -> AsyncGenerator[Any]:
-        label = call.label or "(default)"
-        print(f">>> [run] agent starting  label={label}  tools={len(call.tools)}")
+        print(f">>> [run] agent starting  tools={len(call.tools)}")
         t0 = time.perf_counter()
 
         async for event in next(call):
             yield event
 
         elapsed = time.perf_counter() - t0
-        print(f"<<< [run] agent finished  label={label}  {elapsed:.2f}s")
+        print(f"<<< [run] agent finished  {elapsed:.2f}s")
 
     async def wrap_model(
         self,

--- a/examples/samples/streaming_tool.py
+++ b/examples/samples/streaming_tool.py
@@ -12,7 +12,9 @@ import ai
 
 
 @ai.tool  # type: ignore[arg-type]  # async generator tools are supported at runtime
-async def talk_to_mothership(question: str) -> AsyncGenerator[ai.StreamItem]:
+async def talk_to_mothership(
+    question: str,
+) -> AsyncGenerator[ai.AgentEvent | ai.Message]:
     """Ask the mothership a question. Streams progress back to the caller."""
     for step in ["Connecting...", "Transmitting...", "Awaiting response..."]:
         yield ai.TextStart(block_id=f"progress-{step}")

--- a/skills/ai/SKILL.md
+++ b/skills/ai/SKILL.md
@@ -61,7 +61,6 @@ Key properties on streamed messages:
 - `msg.tool_calls` — list of `ToolCallPart` on assistant messages
 - `msg.output` — validated Pydantic instance (when using `output_type`)
 - `msg.get_hook_part()` — find a hook suspension part
-- `msg.label` — which agent produced the message (for multi-agent)
 
 Serialize: `msg.model_dump()`. Restore: `ai.Message.model_validate(data)`.
 
@@ -129,13 +128,13 @@ async def multi(model: ai.Model, query: str) -> str:
     analyst = ai.agent(tools=[t2])
 
     r1, r2 = await asyncio.gather(
-        ai.yield_from(researcher.run(model, msgs1, label="researcher")),
-        ai.yield_from(analyst.run(model, msgs2, label="analyst")),
+        ai.yield_from(researcher.run(model, msgs1), label="researcher"),
+        ai.yield_from(analyst.run(model, msgs2), label="analyst"),
     )
     return f"{r1}\n{r2}"
 ```
 
-`msg.label` lets the consumer distinguish which agent produced output.
+Each forwarded event is wrapped in `ai.PartialToolCallResult` carrying the `label`, so the consumer can route by source.
 
 ## Hooks
 

--- a/src/ai/__init__.py
+++ b/src/ai/__init__.py
@@ -5,7 +5,7 @@ from .agents import (
     AgentEvent,
     Context,
     HookEvent,
-    StreamItem,
+    PartialToolCallResult,
     TerminalEvent,
     Tool,
     ToolApproval,
@@ -145,10 +145,10 @@ __all__ = [
     # Agents — primary API
     "Agent",
     "AgentEvent",
-    "StreamItem",
     "agent",
     "Context",
     # Agents — tools
+    "PartialToolCallResult",
     "Tool",
     "ToolCall",
     "ToolCallResult",

--- a/src/ai/agents/__init__.py
+++ b/src/ai/agents/__init__.py
@@ -2,7 +2,6 @@ from . import mcp, ui
 from .agent import (
     Agent,
     Context,
-    StreamItem,
     Tool,
     ToolCall,
     ToolRunner,
@@ -11,7 +10,13 @@ from .agent import (
     tool_result,
     yield_from,
 )
-from .events import AgentEvent, HookEvent, TerminalEvent, ToolCallResult
+from .events import (
+    AgentEvent,
+    HookEvent,
+    PartialToolCallResult,
+    TerminalEvent,
+    ToolCallResult,
+)
 from .hooks import (
     TOOL_APPROVAL_HOOK_TYPE,
     ToolApproval,
@@ -23,9 +28,9 @@ from .hooks import (
 __all__ = [
     "Agent",
     "AgentEvent",
-    "StreamItem",
     "Context",
     "HookEvent",
+    "PartialToolCallResult",
     "Tool",
     "ToolApproval",
     "ToolCall",

--- a/src/ai/agents/agent.py
+++ b/src/ai/agents/agent.py
@@ -16,12 +16,6 @@ from ..types import builders
 from . import events as events_
 from . import runtime
 
-# What a streaming-tool generator may yield: AgentEvents pass through
-# to the consumer, and a final bare Message provides the tool's result
-# (its text becomes the return value).  Loop functions yield AgentEvents
-# only — they must call context.add() to update history.
-StreamItem = events_.AgentEvent | types.Message
-
 
 class Tool[**P, R]:
     """Wraps async function, introspects schema, attaches a validator"""
@@ -51,7 +45,13 @@ class Tool[**P, R]:
             return dict(validated.model_dump())
         return kwargs
 
-    async def execute_kwargs(self, kwargs: dict[str, Any]) -> R:
+    async def execute_kwargs(
+        self,
+        kwargs: dict[str, Any],
+        *,
+        tool_name: str | None,
+        tool_call_id: str | None,
+    ) -> R:
         """Validate kwargs and call the underlying tool implementation."""
         kwargs = self.validate_kwargs(kwargs)
         if not self._is_gen:
@@ -60,11 +60,11 @@ class Tool[**P, R]:
         # Generator tool (e.g. agent-as-a-tool): drain the async
         # generator, forward each yielded message to the runtime for
         # real-time streaming, and return the final text as the result.
-        return await yield_from(self._fn(**kwargs))  # type: ignore[arg-type,call-arg,return-value]
-
-    async def __call__(self, json_args: str) -> R:
-        """Parse json_args into kwargs, validate, and call the function."""
-        return await self.execute_kwargs(self.parse_args(json_args))
+        return await yield_from(  # type: ignore[return-value]
+            self._fn(**kwargs),  # type: ignore[arg-type,call-arg]
+            tool_name=tool_name,
+            tool_call_id=tool_call_id,
+        )
 
     @property
     def name(self) -> str:
@@ -167,7 +167,11 @@ class ToolCall:
 
         async def _real(call: middleware_.ToolContext) -> events_.ToolCallResult:
             try:
-                result = await tool.execute_kwargs(call.kwargs)
+                result = await tool.execute_kwargs(
+                    call.kwargs,
+                    tool_call_id=call.tool_call_id,
+                    tool_name=call.tool_name,
+                )
             except Exception as exc:
                 return tool_result(
                     types.ToolResultPart(
@@ -335,20 +339,31 @@ def tool_result(
     return events_.ToolCallResult(message=msg, results=msg.tool_results)
 
 
-async def yield_from(source: AsyncIterable[StreamItem]) -> str:
+async def yield_from(
+    source: AsyncIterable[events_.AgentEvent],
+    *,
+    # TODO: is this what we really want for labelling?
+    tool_name: str | None = None,
+    tool_call_id: str | None = None,
+    label: object = None,
+) -> str:
     """Drain *source*, forwarding each event to the current runtime.
 
     Use inside a custom loop to stream messages from a sub-agent to the
     consumer without adding them to the parent agent's message history::
 
-        result = await yield_from(sub.run(model, msgs, label="researcher"))
+        result = await yield_from(sub.run(model, msgs), label="researcher")
 
     Works with :func:`asyncio.gather` for concurrent fan-out::
 
         r1, r2 = await asyncio.gather(
-            yield_from(a.run(model, m1, label="a")),
-            yield_from(b.run(model, m2, label="b")),
+            yield_from(a.run(model, m1), label="a"),
+            yield_from(b.run(model, m2), label="b"),
         )
+
+    Each forwarded event is wrapped in a :class:`PartialToolCallResult`
+    carrying ``label`` (and optionally ``tool_call_id`` / ``tool_name``)
+    so the consumer can route by source.
 
     Returns the final message's text (empty string if no messages).
     """
@@ -358,7 +373,14 @@ async def yield_from(source: AsyncIterable[StreamItem]) -> str:
         if isinstance(item, types.Message):
             last = item
             continue
-        await rt.put_event(item)
+        await rt.put_event(
+            events_.PartialToolCallResult(
+                tool_call_id=tool_call_id,
+                tool_name=tool_name,
+                label=label,
+                value=item,
+            )
+        )
         if isinstance(item, events_.TerminalEvent):
             last = item.message
     return last.text if last else ""
@@ -415,7 +437,6 @@ class Agent:
         model: models.Model[Any],
         messages: list[types.Message],
         *,
-        label: str | None = None,
         middleware: list[middleware_.Middleware] | None = None,
     ) -> AsyncGenerator[events_.AgentEvent]:
         """Run the agent loop, yielding events to the consumer.
@@ -423,19 +444,18 @@ class Agent:
         Args:
             model: The model to use for LLM calls.
             messages: Initial conversation messages.
-            label: Optional label stamped onto every ``ToolCallResult``
-                emitted by this run (set on its ``message.source_label``).
-                Useful for multi-agent graphs where the consumer needs
-                to route results by source.
             middleware: Optional list of middleware to apply to this run.
                 First in the list = outermost.  Middleware wraps model
                 calls, tool calls, hooks, and the run itself.
+
+        To attribute a sub-agent's events to a branch, wrap the run in
+        ``yield_from(..., label=...)`` — the label flows via
+        ``PartialToolCallResult`` rather than on individual messages.
         """
         call = middleware_.AgentRunContext(
             model=model,
             messages=messages,
             tools=self._tools,
-            label=label,
         )
 
         loop_fn = self._loop_fn or self.default_loop
@@ -450,14 +470,6 @@ class Agent:
             )
             source = loop_fn(context)
             async for event in runtime.run(source):
-                if call.label is not None and isinstance(event, events_.ToolCallResult):
-                    event = event.model_copy(
-                        update={
-                            "message": event.message.model_copy(
-                                update={"source_label": call.label}
-                            )
-                        }
-                    )
                 yield event
 
         # Activate middleware for this run (and everything it calls).

--- a/src/ai/agents/events.py
+++ b/src/ai/agents/events.py
@@ -19,6 +19,18 @@ import pydantic
 from .. import types
 
 
+class PartialToolCallResult(pydantic.BaseModel):
+    """Emitted when tool calls or other yield_from callers yield values."""
+
+    # id: str = pydantic.Field(default_factory=generate_id)
+    tool_call_id: str | None = None
+    tool_name: str | None = None
+    label: object = None
+    value: Any = None
+
+    kind: Literal["partial_tool_call_result"] = "partial_tool_call_result"
+
+
 class ToolCallResult(pydantic.BaseModel):
     """Emitted after tool calls execute — carries the result message."""
 
@@ -39,7 +51,7 @@ class HookEvent(pydantic.BaseModel):
     kind: Literal["hook"] = "hook"
 
 
-AgentEvent = types.Event | ToolCallResult | HookEvent
+AgentEvent = types.Event | ToolCallResult | HookEvent | PartialToolCallResult
 
 TerminalEvent = types.StreamEnd | ToolCallResult | HookEvent
 
@@ -49,4 +61,5 @@ __all__ = [
     "HookEvent",
     "TerminalEvent",
     "ToolCallResult",
+    "PartialToolCallResult",
 ]

--- a/src/ai/agents/ui/ai_sdk/outbound/_state.py
+++ b/src/ai/agents/ui/ai_sdk/outbound/_state.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from .....types import events as events_
 from .....types import messages as messages_
-from ....events import HookEvent, ToolCallResult
+from ....events import HookEvent, PartialToolCallResult, ToolCallResult
 from .. import _approvals, protocol
 
 
@@ -26,7 +26,6 @@ class _StreamState:
     """Single-pass state across one ``to_stream()`` call."""
 
     def __init__(self) -> None:
-        self.current_agent: str | None = None
         self.ui_message_id: str | None = None
         self.emitted_start: bool = False
         self.in_step: bool = False
@@ -72,30 +71,15 @@ class _StreamState:
         self.emitted_tool_results.clear()
         self.emitted_approval_requests.clear()
 
-    def _ensure_started(
-        self, *, source_label: str | None = None
-    ) -> list[protocol.UIMessageStreamPart]:
-        """Lazily emit StartPart / StartStepPart on the first event.
-
-        Also handles agent-change boundaries in multi-agent scenarios.
-        """
+    def _ensure_started(self) -> list[protocol.UIMessageStreamPart]:
+        """Lazily emit StartPart / StartStepPart on the first event."""
         parts: list[protocol.UIMessageStreamPart] = []
-        agent_changed = (
-            self.emitted_start
-            and source_label is not None
-            and source_label != self.current_agent
-        )
 
-        if not self.emitted_start or agent_changed:
-            parts.extend(self._finish_step())
-            if self.emitted_start:
-                parts.append(protocol.FinishPart(finish_reason="stop"))
-
+        if not self.emitted_start:
             parts.append(protocol.StartPart(message_id=None))
             parts.append(protocol.StartStepPart())
             self.emitted_start = True
             self.in_step = True
-            self.current_agent = source_label
             self._reset_step_tracking()
 
         return parts
@@ -186,8 +170,7 @@ class _StreamState:
         msg = event.message
         out: list[protocol.UIMessageStreamPart] = []
 
-        # Ensure the UI message is started (handles agent-change too).
-        out.extend(self._ensure_started(source_label=msg.source_label))
+        out.extend(self._ensure_started())
 
         # Emit ToolInputAvailable for each tool call that triggered
         # these results (from the assistant message's ToolCallParts).
@@ -233,6 +216,12 @@ class _StreamState:
                 )
 
         return out
+
+    def on_partial_tool_result(
+        self, event: PartialToolCallResult
+    ) -> list[protocol.UIMessageStreamPart]:
+        # TODO: Emit something!
+        return []
 
     # -- phase: hooks -------------------------------------------------------
 

--- a/src/ai/agents/ui/ai_sdk/outbound/stream.py
+++ b/src/ai/agents/ui/ai_sdk/outbound/stream.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import AsyncGenerator, AsyncIterable
 
-from ....events import AgentEvent, HookEvent, ToolCallResult
+from ....events import AgentEvent, HookEvent, PartialToolCallResult, ToolCallResult
 from .. import protocol
 from ._state import _StreamState
 
@@ -23,6 +23,9 @@ async def to_stream(
     async for event in events:
         if isinstance(event, ToolCallResult):
             for part in state.on_tool_result(event):
+                yield part
+        elif isinstance(event, PartialToolCallResult):
+            for part in state.on_partial_tool_result(event):
                 yield part
         elif isinstance(event, HookEvent):
             for part in state.on_hook(event):

--- a/src/ai/middleware.py
+++ b/src/ai/middleware.py
@@ -109,7 +109,6 @@ class AgentRunContext:
     model: Model[Any]
     messages: list[messages_.Message]
     tools: list[Tool[..., Any]]
-    label: str | None
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "messages", list(self.messages))

--- a/src/ai/types/messages.py
+++ b/src/ai/types/messages.py
@@ -227,7 +227,6 @@ class Message(pydantic.BaseModel):
     parts: list[Part]
     id: str = pydantic.Field(default_factory=generate_id)
     turn_id: str | None = None
-    source_label: str | None = None
     usage: usage_.Usage | None = None
 
     @property

--- a/tests/agents/test_generator_tools.py
+++ b/tests/agents/test_generator_tools.py
@@ -55,14 +55,19 @@ async def test_generator_tool_streams_and_returns_result() -> None:
 
     assert llm.call_count == 2
 
-    # Intermediate progress events were forwarded to consumer.
-    progress_deltas = [
+    # Intermediate progress events were forwarded to consumer, wrapped
+    # in PartialToolCallResult and attributed to the originating tool call.
+    progress_wrappers = [
         e
         for e in all_events
-        if isinstance(e, events_.TextDelta) and e.block_id == "progress"
+        if isinstance(e, agent_events_.PartialToolCallResult)
+        and isinstance(e.value, events_.TextDelta)
+        and e.value.block_id == "progress"
     ]
-    assert len(progress_deltas) == 1
-    assert progress_deltas[0].chunk == "Working..."
+    assert len(progress_wrappers) == 1
+    assert progress_wrappers[0].value.chunk == "Working..."
+    assert progress_wrappers[0].tool_call_id == "tc-1"
+    assert progress_wrappers[0].tool_name == "progress_tool"
 
     # Tool result was fed back to LLM.
     tool_results = [
@@ -122,7 +127,7 @@ async def research_tool(topic: str) -> AsyncGenerator[agent_events_.AgentEvent]:
         ai.system_message("Be concise."),
         ai.user_message(f"Research: {topic}"),
     ]
-    async for event in inner.run(MOCK_MODEL, msgs, label="inner"):
+    async for event in inner.run(MOCK_MODEL, msgs):
         yield event
 
 
@@ -155,13 +160,18 @@ async def test_yield_from_nested_agent() -> None:
 
     assert adapter.call_count == 3
 
-    # Inner text events were forwarded to the consumer.
+    # Inner text events were forwarded to the consumer, wrapped in
+    # PartialToolCallResult and attributed to the outer tool call.
     inner_text = [
         e
         for e in all_events
-        if isinstance(e, events_.TextDelta) and e.chunk == "Mars has two moons."
+        if isinstance(e, agent_events_.PartialToolCallResult)
+        and isinstance(e.value, events_.TextDelta)
+        and e.value.chunk == "Mars has two moons."
     ]
     assert len(inner_text) > 0
+    assert inner_text[0].tool_call_id == "otc-1"
+    assert inner_text[0].tool_name == "research_tool"
 
     tool_results = [
         e for e in all_events if isinstance(e, agent_events_.ToolCallResult)
@@ -177,7 +187,6 @@ async def test_yield_from_nested_agent() -> None:
 
     # Specifically: no inner assistant text or inner tool results leaked.
     for m in outer_turn2_msgs:
-        assert m.source_label is None or m.source_label != "inner"
         if m.role == "assistant":
             # This must be the outer tool-call message, not inner text.
             assert len(m.tool_calls) > 0

--- a/tests/agents/test_tools.py
+++ b/tests/agents/test_tools.py
@@ -56,19 +56,6 @@ def test_complex_type_schema() -> None:
     assert props["recipients"]["items"]["type"] == "string"
 
 
-# -- Execution (Tool.__call__) --------------------------------------------
-
-
-async def test_tool_call_with_json_args() -> None:
-    @ai.tool
-    async def add(a: int, b: int) -> int:
-        """Add two numbers."""
-        return a + b
-
-    result = await add('{"a": 1, "b": 2}')
-    assert result == 3
-
-
 # -- ToolCall binds a ToolCallPart to a Tool and returns tool messages ----
 
 

--- a/tests/agents/ui/ai_sdk/outbound/test_stream.py
+++ b/tests/agents/ui/ai_sdk/outbound/test_stream.py
@@ -151,51 +151,7 @@ async def test_approval_request_hook_emits_approval_part() -> None:
     assert approval_parts[0].approval_id == "approve_tc1"
 
 
-async def test_agent_change_emits_message_boundary() -> None:
-    """ToolCallResult from a different agent triggers a new StartPart."""
-    tool_result_a = messages_.Message(
-        role="tool",
-        source_label="a1",
-        parts=[
-            messages_.ToolResultPart(
-                tool_call_id="tc1",
-                tool_name="foo",
-                result="ok",
-            )
-        ],
-    )
-    tool_result_b = messages_.Message(
-        role="tool",
-        source_label="a2",
-        parts=[
-            messages_.ToolResultPart(
-                tool_call_id="tc2",
-                tool_name="bar",
-                result="ok",
-            )
-        ],
-    )
-    out = await _collect(
-        [
-            # Agent a1 does text + tool
-            events_.TextStart(block_id="t1"),
-            events_.TextDelta(block_id="t1", chunk="from a"),
-            events_.TextEnd(block_id="t1"),
-            agent_events_.ToolCallResult(
-                message=tool_result_a,
-                results=tool_result_a.tool_results,
-            ),
-            # Agent a2 does text + tool — should trigger new StartPart
-            agent_events_.ToolCallResult(
-                message=tool_result_b,
-                results=tool_result_b.tool_results,
-            ),
-        ]
-    )
-    has_mid_msg_boundary = any(
-        isinstance(out[i], protocol.FinishPart)
-        and i + 1 < len(out)
-        and isinstance(out[i + 1], protocol.StartPart)
-        for i in range(1, len(out) - 1)
-    )
-    assert has_mid_msg_boundary
+# NOTE: agent-change boundary detection used to be driven by
+# Message.source_label.  That field has been removed; agent-change
+# routing in the AI SDK adapter now needs to come from
+# PartialToolCallResult, which is a separate piece of work.


### PR DESCRIPTION
This drops the `label` setup on messages, and instead adds a couple
different ways of labelling to `yield_from`.

We also drop the (not really working anymore anyway, because label was
largely broken by recent changes) label tracking in the outbound
adapter. TODO: Support streaming something here.

There is follow-up still needed in order to support non-subagent
streaming, though.
