### PR TITLE
Report full exceptions out when tools fail

### DIFF
--- a/src/ai/agents/agent.py
+++ b/src/ai/agents/agent.py
@@ -20,6 +20,21 @@ from . import middleware as middleware_
 from . import runtime
 
 
+def _unwrap_singleton_group(exc: BaseException) -> BaseException:
+    """Collapse nested singleton ``BaseExceptionGroup``s to the inner exception.
+
+    A failing task inside an ``asyncio.TaskGroup`` is always re-raised
+    inside an ``ExceptionGroup`` even when there's only one — which
+    obscures the real type and message.  When the group has exactly
+    one child we unwrap so the original exception, traceback, and
+    ``__cause__`` survive.  Multi-error groups stay intact (they
+    really do represent concurrent failures).
+    """
+    while isinstance(exc, BaseExceptionGroup) and len(exc.exceptions) == 1:
+        exc = exc.exceptions[0]
+    return exc
+
+
 class SimpleAggregator[Item, Result](events_.Aggregator[Item, Result, Result]):
     def to_model_output(self) -> Result:
         return self.snapshot()
@@ -380,13 +395,19 @@ class ToolCall:
                 else:
                     result = await tool.fn(**kwargs)
             except Exception as exc:
+                # A nested runtime (e.g. a sub-agent run inside this
+                # tool) raises errors wrapped in a singleton TaskGroup
+                # ExceptionGroup — collapse it so the surfaced type and
+                # message reflect the actual failure.
+                unwrapped = _unwrap_singleton_group(exc)
                 return tool_result(
                     types.messages.ToolResultPart(
                         tool_call_id=call.tool_call_id,
                         tool_name=call.tool_name,
-                        result=str(exc),
+                        result=f"{type(unwrapped).__name__}: {unwrapped}",
                         is_error=True,
-                    )
+                    ),
+                    exception=unwrapped,
                 )
             return tool_result(
                 types.messages.ToolResultPart(
@@ -525,6 +546,7 @@ def tool_result(
     result: Any = None,
     tool_name: str = "",
     is_error: bool = False,
+    exception: BaseException | None = None,
 ) -> events_.ToolCallResult:
     """Create a :class:`ToolCallResult` from tool messages, parts, or kwargs.
 
@@ -534,6 +556,10 @@ def tool_result(
 
         yield ai.tool_result(*(t.result() for t in tasks))
         ai.tool_result(tool_call_id="tc-1", result="denied", is_error=True)
+
+    Pass ``exception=`` to attach the raised :class:`BaseException` to
+    the returned event for richer logging downstream — the wire-bound
+    ``ToolResultPart`` only carries ``str(exc)``.
     """
     if tool_call_id is not None:
         msg = builders.tool_message(
@@ -542,7 +568,9 @@ def tool_result(
             tool_name=tool_name,
             is_error=is_error,
         )
-        return events_.ToolCallResult(message=msg, results=msg.tool_results)
+        return events_.ToolCallResult(
+            message=msg, results=msg.tool_results, exception=exception
+        )
 
     unwrapped: list[types.messages.Message | types.messages.ToolResultPart] = []
     for item in items:
@@ -553,7 +581,9 @@ def tool_result(
         else:
             unwrapped.append(item)
     msg = builders.tool_message(*unwrapped)
-    return events_.ToolCallResult(message=msg, results=msg.tool_results)
+    return events_.ToolCallResult(
+        message=msg, results=msg.tool_results, exception=exception
+    )
 
 
 async def yield_from[T, R](

--- a/src/ai/types/events.py
+++ b/src/ai/types/events.py
@@ -216,10 +216,20 @@ class PartialToolCallResult(pydantic.BaseModel):
 
 
 class ToolCallResult(pydantic.BaseModel):
-    """Emitted after tool calls execute -- carries the result message."""
+    """Emitted after tool calls execute — carries the result message.
+
+    When the framework auto-catches an exception raised by the tool,
+    ``exception`` carries the real ``BaseException`` (with traceback /
+    ``__cause__`` intact) so loops can log it richly.  The wire-bound
+    ``ToolResultPart.result`` still has ``str(exc)`` for the LLM.
+    The ``exception`` field is excluded from serialization.
+    """
 
     message: messages.Message
     results: Sequence[messages.ToolResultPart]
+    exception: BaseException | None = pydantic.Field(
+        default=None, exclude=True, repr=False
+    )
 
     model_config = pydantic.ConfigDict(arbitrary_types_allowed=True)
 

--- a/tests/agents/test_tools.py
+++ b/tests/agents/test_tools.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 
 import pydantic
@@ -120,6 +121,43 @@ async def test_tool_call_catches_errors() -> None:
 
     assert result.results[0].is_error
     assert "boom" in str(result.results[0].result)
+    # The real exception is preserved on the event for richer logging.
+    assert isinstance(result.exception, ValueError)
+    assert str(result.exception) == "boom"
+
+
+async def test_tool_call_unwraps_singleton_exceptiongroup() -> None:
+    """When a tool's body raises an ExceptionGroup wrapping a single
+    exception (typical when it runs an asyncio TaskGroup internally),
+    the auto-catch surfaces the underlying error — not the group."""
+
+    class BoomError(RuntimeError):
+        pass
+
+    @ai.tool
+    async def fail_via_group(x: int) -> int:
+        """Fails inside a TaskGroup."""
+
+        async def _inner() -> None:
+            raise BoomError("kaboom")
+
+        async with asyncio.TaskGroup() as tg:
+            tg.create_task(_inner())
+        return x  # unreachable
+
+    part = ai.messages.ToolCallPart(
+        tool_call_id="tc-grp",
+        tool_name="fail_via_group",
+        tool_args='{"x": 1}',
+    )
+    tc = ai.ToolCall(part=part, tool=fail_via_group)
+    result = await tc()
+
+    assert result.results[0].is_error
+    # Result text reflects the unwrapped exception type, not BaseExceptionGroup.
+    assert "BoomError" in str(result.results[0].result)
+    assert "kaboom" in str(result.results[0].result)
+    assert isinstance(result.exception, BoomError)
 
 
 async def test_tool_call_allows_kwarg_overrides() -> None:


### PR DESCRIPTION
This enables better logging and stuff.
We may want to consider logging by default?
