### PR TITLE
Make `merge` restart streams, get rid of stream argument to ToolRunner

### DIFF
--- a/examples/multiagent-textual/server.py
+++ b/examples/multiagent-textual/server.py
@@ -111,7 +111,7 @@ def _gated_agent(
         while context.keep_running():
             async with (
                 ai.stream(context.model, context.messages, tools=context.tools) as s,
-                ai.agents.ToolRunner(s) as tr,
+                ai.agents.ToolRunner() as tr,
             ):
                 async for event in ai.util.merge(s, tr.events()):
                     yield event

--- a/examples/samples/agent_custom_loop.py
+++ b/examples/samples/agent_custom_loop.py
@@ -30,7 +30,7 @@ class CustomAgent(ai.Agent):
                 ai.models.stream(
                     context.model, context.messages, tools=context.tools
                 ) as stream,
-                ai.ToolRunner(stream) as tr,
+                ai.ToolRunner() as tr,
             ):
                 async for event in ai.util.merge(stream, tr.events()):
                     yield event

--- a/examples/samples/agent_hooks.py
+++ b/examples/samples/agent_hooks.py
@@ -71,7 +71,7 @@ async def main() -> None:
         while context.keep_running():
             async with (
                 ai.stream(context.model, context.messages, tools=context.tools) as s,
-                ai.ToolRunner(s) as tr,
+                ai.ToolRunner() as tr,
             ):
                 async for event in ai.util.merge(s, tr.events()):
                     yield event

--- a/examples/samples/agent_hooks_inline.py
+++ b/examples/samples/agent_hooks_inline.py
@@ -47,7 +47,7 @@ async def main() -> None:
         while context.keep_running():
             async with (
                 ai.stream(context.model, context.messages, tools=context.tools) as s,
-                ai.ToolRunner(s) as tr,
+                ai.ToolRunner() as tr,
             ):
                 async for event in ai.util.merge(s, tr.events()):
                     yield event

--- a/src/ai/agents/agent.py
+++ b/src/ai/agents/agent.py
@@ -432,13 +432,16 @@ class ToolCallLike(Protocol):
     def __call__(self) -> Coroutine[Any, Any, events_.ToolCallResult]: ...
 
 
+class _RestartableToolStream:
+    def __init__(self, tr: ToolRunner) -> None:
+        self._tr = tr
+
+    def __aiter__(self) -> AsyncGenerator[events_.ToolCallResult]:
+        return self._tr._iterate()
+
+
 class ToolRunner:
-    def __init__(self, stream: models.Stream) -> None:
-        self._stream = stream
-        # finish_future gets set when the stream exhausts. We won't
-        # exhaust until that happens, since the stream can cause more
-        # tools to get triggered.
-        self._finish_future = stream.finish_future
+    def __init__(self) -> None:
         # A future that gets signalled when we add a new tool, so that
         # asyncio.wait gets woken up and cycles around in the loop to
         # wait on the new thing as well.
@@ -448,7 +451,8 @@ class ToolRunner:
         )
         self._active: set[
             asyncio.Future[events_.ToolCallResult] | asyncio.Future[None]
-        ] = {self._finish_future}
+        ] = set()
+
         self._new_results: list[events_.ToolCallResult] = []
         self._tool_results: list[events_.ToolCallResult] = []
         self._tg_base = asyncio.TaskGroup()
@@ -460,8 +464,8 @@ class ToolRunner:
     async def __aexit__(self, *args: Any) -> None:
         return await self._tg_base.__aexit__(*args)
 
-    def events(self) -> AsyncGenerator[events_.ToolCallResult]:
-        return self._iterate()
+    def events(self) -> _RestartableToolStream:
+        return _RestartableToolStream(self)
 
     def schedule(self, tc: ToolCallLike) -> None:
         """Schedule a tool call (or any callable producing a ToolCallResult).
@@ -473,14 +477,16 @@ class ToolRunner:
         runner's merge-and-iterate flow.
         """
         self._active.add(self._tg.create_task(tc()))
-        self._sched_waiter.set_result(None)
+        if not self._sched_waiter.done():
+            self._sched_waiter.set_result(None)
 
     def add_result(self, res: events_.ToolCallResult) -> None:
         self._tool_results.append(res)
 
         # Also add to _new_results and signal sched_waiter to return them
         self._new_results.append(res)
-        self._sched_waiter.set_result(None)
+        if not self._sched_waiter.done():
+            self._sched_waiter.set_result(None)
 
     def get_tool_message(self) -> types.messages.Message | None:
         if self._tool_results:
@@ -495,9 +501,7 @@ class ToolRunner:
             )
             for t in done:
                 self._active.discard(t)
-                if t is self._finish_future:
-                    t.result()
-                elif t is self._sched_waiter:
+                if t is self._sched_waiter:
                     t.result()
 
                     new = self._new_results
@@ -710,7 +714,7 @@ class Agent:
                 models.stream(
                     context.model, context.messages, tools=context.tools
                 ) as stream,
-                ToolRunner(stream) as tr,
+                ToolRunner() as tr,
             ):
                 async for event in util.merge(stream, tr.events()):
                     yield event

--- a/src/ai/models/core/api.py
+++ b/src/ai/models/core/api.py
@@ -1,4 +1,3 @@
-import asyncio
 import dataclasses
 from collections.abc import AsyncGenerator, Sequence
 from typing import Any, Protocol, Self, cast, runtime_checkable
@@ -137,13 +136,6 @@ class Stream:
             role="assistant", parts=[]
         )
         self._parts: dict[str, types.messages.Part] = {}
-        self._finish_future: asyncio.Future[None] = (
-            asyncio.get_event_loop().create_future()
-        )
-
-    @property
-    def finish_future(self) -> asyncio.Future[None]:
-        return self._finish_future
 
     async def __aenter__(self) -> Self:
         return self
@@ -166,7 +158,6 @@ class Stream:
         except Exception:
             # Usually this fires on StopAsyncIteration, but could be a
             # real exception too
-            self._finish_future.set_result(None)
             raise
         updates = self._aggregate_event(event)
         return event.model_copy(update={"message": self._message, **updates})

--- a/src/ai/util.py
+++ b/src/ai/util.py
@@ -115,12 +115,35 @@ async def decouple[T](
             await task
 
 
-async def merge[T](*aiterables: AsyncIterable[T]) -> AsyncIterator[T]:
+async def merge[T](
+    *aiterables: AsyncIterable[T], restart: bool = True
+) -> AsyncIterator[T]:
+    """Produce a stream that yields elements from async iterables as they arrive.
+
+    Additionally, if `restart` is True (the default), attempt to *restart*
+    finished iterables when other iterables produce elements.
+
+    This allows supporting interacting streams, where the processing
+    loop might trigger work in one stream based on results from
+    another.
+
+    Restarts are only attempted for iterables that are not their own
+    iterators (importantly, this means that async generators are not
+    restarted).
+    """
+
     # We use unwrap_generator_exit() to keep a GeneratorExit that gets
     # packaged in an ExceptionGroup from causing grief. But maybe we
     # ought to not use a TaskGroup?
     async with unwrap_generator_exit(), asyncio.TaskGroup() as tg:
-        aiters = [decouple(iter, task_group=tg) for iter in aiterables]
+        raw_aiters = [aiter(iter) for iter in aiterables]
+        aiters = [decouple(iter, task_group=tg) for iter in raw_aiters]
+        # We consider anything that doesn't __aiter__ to itself to be
+        # potentially restartable.
+        restartable = [
+            aiterable is not aiterator
+            for aiterable, aiterator in zip(aiterables, raw_aiters, strict=True)
+        ]
 
         # Launch a task doing anext on every iterator
         tasks: list[asyncio.Future[T] | None] = [
@@ -133,6 +156,7 @@ async def merge[T](*aiterables: AsyncIterable[T]) -> AsyncIterator[T]:
                 return_when=asyncio.FIRST_COMPLETED,
             )
 
+            fired = []
             for t in done:
                 idx = tasks.index(t)
                 val = t.result()
@@ -140,6 +164,17 @@ async def merge[T](*aiterables: AsyncIterable[T]) -> AsyncIterator[T]:
                     tasks[idx] = None
                 else:
                     # Fire off a new task for the relevant iterator
+                    fired.append(idx)
                     iter = aiters[idx]
                     tasks[idx] = tg.create_task(anext(iter, _EMPTY))
                     yield val
+
+            if restart and fired:
+                # Also, we try *restarting* other stopped streams
+                # that may have more to do now.
+                # N.B: We do this *after* the yield...
+                for idx, (ok, otask) in enumerate(zip(restartable, tasks, strict=True)):
+                    if ok and otask is None and idx not in fired:
+                        niter = decouple(aiterables[idx], task_group=tg)
+                        aiters[idx] = niter
+                        tasks[idx] = tg.create_task(anext(niter, _EMPTY))

--- a/src/ai/util.py
+++ b/src/ai/util.py
@@ -172,7 +172,10 @@ async def merge[T](
             if restart and fired:
                 # Also, we try *restarting* other stopped streams
                 # that may have more to do now.
-                # N.B: We do this *after* the yield...
+                # N.B: We do this *after* the values are yielded, so
+                # they've had a chance to trigger things, and we do it
+                # after *all* tasks have been handled, so that if a
+                # task *just* finished, we still restart it.
                 for idx, (ok, otask) in enumerate(zip(restartable, tasks, strict=True)):
                     if ok and otask is None and idx not in fired:
                         niter = decouple(aiterables[idx], task_group=tg)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -550,6 +550,69 @@ async def test_merge_restart_only_after_other_iterable_yields() -> None:
     assert src.iter_count == 1
 
 
+async def test_merge_restart_when_yield_and_stop_collide() -> None:
+    """Restart still fires when a yield and a restartable's exhaustion land
+    in the same ``asyncio.wait`` step.
+
+    If merge processes the yielding task before the stopping one inside the
+    same ``done`` set, the stopping iter's slot is still its original task
+    (not ``None``) at the moment a too-eager restart pass runs — so the
+    restartable never gets re-iterated to pick up items pushed by the
+    consumer in response to the yield.
+
+    ``done`` is a ``set`` so its iteration order is hash-driven (by task
+    ``id``); we can't force the bad order portably, so the scenario runs
+    many times to make the bad order overwhelmingly likely. Empirically
+    each iteration fails ~50% of the time with the bug, so 25 iterations
+    gives a miss-rate of ~10⁻⁸.
+    """
+
+    class _DelayedEmpty:
+        """A restartable whose ``__aiter__`` always sleeps before yielding.
+
+        With the same delay as the driver's yield, its initial-empty anext
+        completes _at the same simulated time_ as the driver's item, putting
+        both in the same ``done`` set.
+        """
+
+        def __init__(self) -> None:
+            self.iter_count = 0
+            self._items: list[Any] = []
+
+        def push(self, *items: Any) -> None:
+            self._items.extend(items)
+
+        def __aiter__(self) -> AsyncIterator[Any]:
+            self.iter_count += 1
+            items = list(self._items)
+            self._items.clear()
+
+            async def gen() -> AsyncIterator[Any]:
+                await asyncio.sleep(10)
+                for x in items:
+                    yield x
+
+            return gen()
+
+    async def one_run() -> list[str]:
+        src = _DelayedEmpty()  # initially empty: first iter yields nothing
+
+        async def driver() -> AsyncIterator[str]:
+            await asyncio.sleep(10)
+            yield "d1"
+
+        results: list[str] = []
+        async for item in util.merge(driver(), src):
+            results.append(item)
+            if item == "d1":
+                src.push("r1")
+        return results
+
+    for _ in range(25):
+        results = await one_run()
+        assert sorted(results) == ["d1", "r1"], results
+
+
 def test_merge_cleanup_on_asyncio_shutdown() -> None:
     """A leaked partially-consumed merge gen is cleaned up correctly on shutdown.
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -414,6 +414,142 @@ async def test_merge_preserves_contextvar_across_yields() -> None:
     assert items == [1, 2]
 
 
+# -- merge: restart --------------------------------------------------------
+
+
+class _Restartable:
+    """An iterable whose ``__aiter__`` returns a fresh async generator each call.
+
+    Items can be queued via ``push``; each iteration drains the queue and stops.
+    Tracks how many times ``__aiter__`` has been called.
+    """
+
+    def __init__(self) -> None:
+        self._items: list[Any] = []
+        self.iter_count = 0
+
+    def push(self, *items: Any) -> None:
+        self._items.extend(items)
+
+    def __aiter__(self) -> AsyncIterator[Any]:
+        self.iter_count += 1
+        items = list(self._items)
+        self._items.clear()
+
+        async def gen() -> AsyncIterator[Any]:
+            for x in items:
+                yield x
+
+        return gen()
+
+
+async def test_merge_restarts_restartable_iterable() -> None:
+    """A restartable iterable is re-iterated when another iterable yields."""
+    src = _Restartable()
+    src.push("r1")
+
+    async def driver() -> AsyncIterator[str]:
+        await asyncio.sleep(10)
+        src.push("r2")
+        yield "d1"
+        await asyncio.sleep(10)
+        src.push("r3", "r4")
+        yield "d2"
+        await asyncio.sleep(10)
+        yield "d3"
+
+    result = await _collect(util.merge(driver(), src))
+    assert sorted(result) == ["d1", "d2", "d3", "r1", "r2", "r3", "r4"]
+    # __aiter__ called once initially + once after each driver yield.
+    assert src.iter_count == 4
+
+
+async def test_merge_does_not_restart_async_generator() -> None:
+    """A bare async generator (its own iterator) is not re-iterated."""
+    runs = 0
+
+    async def gen() -> AsyncIterator[str]:
+        nonlocal runs
+        runs += 1
+        yield "g"
+
+    async def driver() -> AsyncIterator[str]:
+        await asyncio.sleep(10)
+        yield "d1"
+        await asyncio.sleep(10)
+        yield "d2"
+
+    result = await _collect(util.merge(driver(), gen()))
+    assert sorted(result) == ["d1", "d2", "g"]
+    assert runs == 1
+
+
+async def test_merge_restart_false_disables_restart() -> None:
+    """``restart=False`` prevents re-iterating restartable iterables."""
+    src = _Restartable()
+    src.push("r1")
+
+    async def driver() -> AsyncIterator[str]:
+        await asyncio.sleep(10)
+        src.push("never1")
+        yield "d1"
+        await asyncio.sleep(10)
+        src.push("never2")
+        yield "d2"
+
+    result = await _collect(util.merge(driver(), src, restart=False))
+    assert sorted(result) == ["d1", "d2", "r1"]
+    assert src.iter_count == 1
+
+
+async def test_merge_restart_with_no_new_items_terminates() -> None:
+    """A restart with nothing to yield doesn't cause merge to loop forever."""
+    src = _Restartable()
+    src.push("only")
+
+    async def driver() -> AsyncIterator[str]:
+        await asyncio.sleep(10)
+        yield "d1"
+        await asyncio.sleep(10)
+        yield "d2"
+
+    result = await _collect(util.merge(driver(), src))
+    assert sorted(result) == ["d1", "d2", "only"]
+    # Still re-iterated once per driver yield, even though nothing new arrived.
+    assert src.iter_count == 3
+
+
+async def test_merge_restart_with_multiple_restartables() -> None:
+    """Multiple restartable iterables are each re-iterated when others fire."""
+    a = _Restartable()
+    b = _Restartable()
+    a.push("a1")
+    b.push("b1")
+
+    async def driver() -> AsyncIterator[str]:
+        await asyncio.sleep(10)
+        a.push("a2")
+        b.push("b2")
+        yield "d1"
+
+    result = await _collect(util.merge(driver(), a, b))
+    assert sorted(result) == ["a1", "a2", "b1", "b2", "d1"]
+    assert a.iter_count == 2
+    assert b.iter_count == 2
+
+
+async def test_merge_restart_only_after_other_iterable_yields() -> None:
+    """Restart is triggered by another iterable yielding, not by self-completion."""
+    src = _Restartable()
+    src.push("r1")
+
+    # Single-iterable merge: src exhausts itself and merge ends without
+    # __aiter__ being called again.
+    result = await _collect(util.merge(src))
+    assert result == ["r1"]
+    assert src.iter_count == 1
+
+
 def test_merge_cleanup_on_asyncio_shutdown() -> None:
     """A leaked partially-consumed merge gen is cleaned up correctly on shutdown.
 


### PR DESCRIPTION
If merge knows how to restart streams, then ToolRunner can be
restartable instead of specifically dealing with stream closure.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>