### PR TITLE
Add durability test for temporal-direct

### DIFF
--- a/examples/run-examples.py
+++ b/examples/run-examples.py
@@ -66,9 +66,11 @@ BROKEN_SAMPLES = [
 ]
 
 # E2E tests pick non-default ports so they don't collide with a running
-# dev server on 8000/5173.
-_E2E_BACKEND_PORT = "18000"
-_E2E_FRONTEND_PORT = "15173"
+# dev server on 8000/5173. Each test gets its own ports so that --parallel
+# doesn't make them collide with each other either.
+_MULTIAGENT_SERVER_PORT = "18000"
+_FASTAPI_BACKEND_PORT = "18001"
+_FASTAPI_FRONTEND_PORT = "15173"
 
 E2E_TESTS = [
     Sample(
@@ -82,7 +84,7 @@ E2E_TESTS = [
             "python",
             str(REPO / "examples" / "multiagent-textual" / "test-e2e.py"),
         ],
-        extra_env={"SERVER_PORT": _E2E_BACKEND_PORT},
+        extra_env={"SERVER_PORT": _MULTIAGENT_SERVER_PORT},
         timeout=300.0,
     ),
     Sample(
@@ -92,9 +94,24 @@ E2E_TESTS = [
             str(REPO / "examples" / "fastapi-vite" / "e2e-test" / "run.sh"),
         ],
         extra_env={
-            "BACKEND_PORT": _E2E_BACKEND_PORT,
-            "FRONTEND_PORT": _E2E_FRONTEND_PORT,
+            "BACKEND_PORT": _FASTAPI_BACKEND_PORT,
+            "FRONTEND_PORT": _FASTAPI_FRONTEND_PORT,
         },
+        timeout=300.0,
+    ),
+    Sample(
+        "temporal-direct/test_durability.py",
+        cmd=[
+            "uv",
+            "run",
+            "--frozen",
+            "--directory",
+            str(REPO / "examples" / "temporal-direct"),
+            "--with-editable",
+            str(REPO),
+            "python",
+            "test_durability.py",
+        ],
         timeout=300.0,
     ),
 ]

--- a/examples/temporal-direct/_durability_worker.py
+++ b/examples/temporal-direct/_durability_worker.py
@@ -1,0 +1,115 @@
+"""Subprocess worker for ``test_durability``.
+
+Run in its own process so the parent test can shut it down by signal
+instead of doing a graceful in-process ``worker.shutdown()`` — which
+leaves cached ``WorkflowInstance``\\ s and their pending asyncio tasks
+alive in memory and produces unraisable context-mismatch errors at
+interpreter shutdown. With a subprocess, the residue dies with the
+process; the parent never sees it.
+
+We use ``SIGINT`` (raises ``KeyboardInterrupt`` → ``asyncio.run``
+cleans up → ``Worker.__aexit__`` runs ``shutdown()``) rather than
+``SIGKILL``. ``SIGKILL`` would leave any in-flight activity hanging
+until ``start_to_close_timeout`` fires (5 min for the LLM activity),
+which makes the test painfully slow. The ``SIGINT`` path is what a
+production rollout's ``preStop``/``SIGTERM`` looks like in spirit.
+
+Activities log every completion to a file named in
+``DURABILITY_ACTIVITY_LOG`` so the parent can count executions across
+the process boundary.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import contextlib
+import os
+import threading
+from collections.abc import Callable
+from typing import Any
+
+import main as ex
+import temporalio.activity
+import temporalio.client
+import temporalio.worker
+
+_log_lock = threading.Lock()
+
+
+def _log_activity(name: str) -> None:
+    log_file = os.environ.get("DURABILITY_ACTIVITY_LOG")
+    if not log_file:
+        return
+    with _log_lock, open(log_file, "a") as f:
+        f.write(f"{name}\n")
+
+
+# Activities log *after* completion so the file is a record of activities
+# that actually finished (on whichever worker ran them). If a worker dies
+# mid-activity, that attempt never logs; only the eventual completion (on
+# the same or a different worker) does. The crash test relies on this:
+# pre-restart counts == activities completed on worker1, and post-restart
+# total should equal one full workflow's worth of completions.
+
+
+@temporalio.activity.defn(name="get_weather_activity")
+async def logged_get_weather(city: str) -> str:
+    result = await ex.get_weather_activity(city)
+    _log_activity("get_weather")
+    return result
+
+
+@temporalio.activity.defn(name="get_population_activity")
+async def logged_get_population(city: str) -> int:
+    result = await ex.get_population_activity(city)
+    _log_activity("get_population")
+    return result
+
+
+@temporalio.activity.defn(name="llm_call_activity")
+async def logged_llm_call(params: ex.LLMParams) -> ex.LLMResult:
+    result = await ex.llm_call_activity(params)
+    _log_activity("llm_call")
+    return result
+
+
+LOGGED_ACTIVITIES: list[Callable[..., Any]] = [
+    logged_llm_call,
+    logged_get_weather,
+    logged_get_population,
+]
+
+
+async def amain(server_addr: str, namespace: str) -> None:
+    client = await temporalio.client.Client.connect(server_addr, namespace=namespace)
+    async with temporalio.worker.Worker(
+        client,
+        task_queue=ex.TASK_QUEUE,
+        workflows=[ex.WeatherWorkflow],
+        activities=LOGGED_ACTIVITIES,
+        # Serialize activities so the parent has a deterministic window
+        # to interrupt between them (the workflow's tool batch is
+        # ``asyncio.gather``-parallel; without this knob, the four tool
+        # activities all complete before the parent's poll loop wakes).
+        max_concurrent_activities=1,
+    ):
+        # Run forever. The parent sends SIGINT when it's done.
+        with contextlib.suppress(KeyboardInterrupt, asyncio.CancelledError):
+            await asyncio.Event().wait()
+
+
+if __name__ == "__main__":
+    p = argparse.ArgumentParser()
+    p.add_argument("--server-addr", required=True)
+    p.add_argument("--namespace", default="default")
+    args = p.parse_args()
+    asyncio.run(amain(args.server_addr, args.namespace))
+    # Skip the interpreter's atexit / final-GC pass. The cached
+    # ``WorkflowInstance`` is still in memory at this point; letting GC
+    # close its leaked coroutines would print "Exception ignored …
+    # ContextVar … was created in a different Context" to our (inherited)
+    # stderr, which the parent test would treat as a failure. Real
+    # production worker death is process exit without Python cleanup, so
+    # this matches that semantics: memory dies with the process.
+    os._exit(0)

--- a/examples/temporal-direct/main.py
+++ b/examples/temporal-direct/main.py
@@ -166,7 +166,9 @@ async def temporal_loop(context: ai.Context) -> AsyncGenerator[ai.events.AgentEv
 
         tasks = [asyncio.ensure_future(run_tool(tc)) for tc in msg.tool_calls]
         parts = await asyncio.gather(*tasks)
-        yield ai.tool_result(*parts)
+        result_event = ai.tool_result(*parts)
+        yield result_event
+        context.add(result_event.message)
 
 
 # ── Workflow ─────────────────────────────────────────────────────

--- a/examples/temporal-direct/test_durability.py
+++ b/examples/temporal-direct/test_durability.py
@@ -1,0 +1,272 @@
+"""Durability tests for ``temporal-direct/main.py``.
+
+Three checks:
+
+1. **Happy path** — the workflow runs end-to-end via an embedded dev
+   server and produces a non-empty text answer.
+
+2. **Replay determinism** — the recorded event history of a successful
+   run replays cleanly against the current workflow code (no
+   non-determinism error). This is what catches accidental sources of
+   non-determinism (clocks, randomness, set iteration order, etc.) in
+   the loop or the framework.
+
+3. **Activity caching across a worker restart** — start worker1 in a
+   subprocess, kick off the workflow, ``SIGINT`` the subprocess
+   mid-flight, then start a fresh in-process worker. A file-backed
+   activity log proves that activities completed before the crash are
+   *not* re-executed: their results are served from history.
+
+   The subprocess pattern matters: a graceful in-process
+   ``worker.shutdown()`` leaves the cached ``WorkflowInstance`` alive
+   in memory with its asyncio tasks pending, which produces unraisable
+   context-mismatch errors when GC eventually closes those coroutines.
+   Real worker death is process death, where in-memory residue is a
+   non-issue — and that's what we simulate here. (We use ``SIGINT``
+   rather than ``SIGKILL`` so the subprocess gets a chance to cancel
+   its in-flight activity instead of leaving it pinned for
+   ``start_to_close_timeout``; the subprocess exits via ``os._exit``
+   to skip the GC pass that would otherwise emit the same unraisables.)
+
+Run with::
+
+    AI_GATEWAY_API_KEY=... uv run python test_durability.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import gc
+import os
+import pathlib
+import signal
+import sys
+import tempfile
+import traceback
+import uuid
+from collections import Counter
+from typing import Any
+
+import main as ex
+import temporalio.client
+import temporalio.testing
+import temporalio.worker
+from _durability_worker import LOGGED_ACTIVITIES
+
+# ── Helpers ──────────────────────────────────────────────────────
+
+
+def make_worker(client: temporalio.client.Client) -> temporalio.worker.Worker:
+    return temporalio.worker.Worker(
+        client,
+        task_queue=ex.TASK_QUEUE,
+        workflows=[ex.WeatherWorkflow],
+        activities=LOGGED_ACTIVITIES,
+    )
+
+
+def read_activity_log(log_file: pathlib.Path) -> Counter[str]:
+    if not log_file.exists():
+        return Counter()
+    return Counter(log_file.read_text().splitlines())
+
+
+QUERY = "What's the weather and population of New York and Los Angeles?"
+
+
+# ── Test 1: happy path ───────────────────────────────────────────
+
+
+async def test_happy_path(
+    client: temporalio.client.Client, log_file: pathlib.Path
+) -> str:
+    print("\n── test_happy_path ────────────────────────────────")
+    log_file.write_text("")
+
+    async with make_worker(client):
+        wid = f"happy-{uuid.uuid4().hex[:8]}"
+        result = await client.execute_workflow(
+            ex.WeatherWorkflow.run,
+            QUERY,
+            id=wid,
+            task_queue=ex.TASK_QUEUE,
+        )
+
+    assert result, "expected non-empty text"
+    assert "8,336,817" in result or "8336817" in result, (
+        f"expected NYC population in result, got: {result!r}"
+    )
+    print(f"  ✓ workflow {wid} produced {len(result)} chars")
+    print(f"  ✓ activity calls: {dict(read_activity_log(log_file))}")
+    return wid
+
+
+# ── Test 2: replay determinism ───────────────────────────────────
+
+
+async def test_replay_determinism(
+    client: temporalio.client.Client, workflow_id: str
+) -> None:
+    print("\n── test_replay_determinism ────────────────────────")
+    handle = client.get_workflow_handle(workflow_id)
+    history = await handle.fetch_history()
+
+    replayer = temporalio.worker.Replayer(workflows=[ex.WeatherWorkflow])
+    # Raises a non-determinism error if the recorded events don't
+    # line up with what the current workflow code would produce.
+    await replayer.replay_workflow(history)
+    print(f"  ✓ replay clean for {workflow_id} ({len(history.events)} events)")
+
+
+# ── Test 3: activity caching across a worker restart ─────────────
+
+
+async def test_activity_caching(
+    env: temporalio.testing.WorkflowEnvironment,
+    client: temporalio.client.Client,
+    log_file: pathlib.Path,
+) -> None:
+    print("\n── test_activity_caching ──────────────────────────")
+    log_file.write_text("")
+
+    wid = f"resume-{uuid.uuid4().hex[:8]}"
+
+    # Worker 1 lives in a subprocess so we can shut it down by signal,
+    # mimicking real worker process death. The child inherits stdout/
+    # stderr so any Temporal output is visible in our logs.
+    worker_script = pathlib.Path(__file__).parent / "_durability_worker.py"
+    proc = await asyncio.create_subprocess_exec(
+        sys.executable,
+        str(worker_script),
+        "--server-addr",
+        client.service_client.config.target_host,
+        "--namespace",
+        client.namespace,
+        env={**os.environ, "DURABILITY_ACTIVITY_LOG": str(log_file)},
+    )
+    try:
+        # No READY handshake needed: ``start_workflow`` queues the run
+        # server-side; whichever worker shows up first picks it up.
+        handle = await client.start_workflow(
+            ex.WeatherWorkflow.run,
+            QUERY,
+            id=wid,
+            task_queue=ex.TASK_QUEUE,
+        )
+        # Poll the activity log for completions written by the subprocess.
+        # Wait until we've seen the first LLM call and at least one tool
+        # complete: that puts us partway through the workflow with several
+        # activities still to schedule, so worker2 has actual work to do.
+        deadline = asyncio.get_event_loop().time() + 30
+        while asyncio.get_event_loop().time() < deadline:
+            counts = read_activity_log(log_file)
+            if counts.get("llm_call", 0) >= 1 and counts.total() >= 2:
+                break
+            await asyncio.sleep(0.05)
+        else:
+            raise AssertionError(
+                "no activities executed before timeout — worker slow to start?"
+            )
+    finally:
+        # SIGINT → KeyboardInterrupt → asyncio.run cleans up → Worker
+        # graceful shutdown (default ``graceful_shutdown_timeout=0``
+        # cancels in-flight activities immediately so the test isn't
+        # held hostage by ``start_to_close_timeout``). The subprocess
+        # dies; any in-memory residue dies with it.
+        if proc.returncode is None:
+            proc.send_signal(signal.SIGINT)
+            await proc.wait()
+
+    pre_restart = dict(read_activity_log(log_file))
+    print(f"  pre-restart activity calls (worker1): {pre_restart}")
+
+    # Worker 2: in-process. Workflow resumes from history.
+    async with make_worker(client):
+        result = await handle.result()
+
+    post_restart = dict(read_activity_log(log_file))
+    print(f"  post-restart activity calls (worker1+worker2): {post_restart}")
+    assert result, "workflow returned empty result after resume"
+
+    total_pre = sum(pre_restart.values())
+    total_post = sum(post_restart.values())
+
+    # Sanity: we actually killed worker1 mid-workflow. If worker1 had
+    # finished everything before the SIGINT landed, the test would
+    # vacuously "pass" the cache invariant without exercising resume.
+    assert total_post > total_pre, (
+        f"worker1 finished the entire workflow before shutdown landed "
+        f"(pre={total_pre}, post={total_post}); test isn't exercising resume"
+    )
+
+    # If worker2 ignored history and re-ran everything, total_post would
+    # be roughly 2× total_pre (worker1's executions + worker2 redoing
+    # them all). Catch that case loudly.
+    expected_double_run = total_pre * 2
+    assert total_post < expected_double_run, (
+        f"suspiciously high activity count after resume: {total_post} "
+        f"(would expect at most ~{expected_double_run - 1} if cache replayed)"
+    )
+    print("  ✓ resume completed without re-running cached activities")
+    print(f"    (total before: {total_pre}, after: {total_post})")
+
+
+# ── Entry point ──────────────────────────────────────────────────
+#
+# Coroutine cleanup that raises during asyncio shutdown surfaces as
+# "Exception ignored while closing generator …" via ``sys.unraisablehook``
+# rather than propagating out of ``asyncio.run``. For a durability test
+# that's a real failure — capture them and fail at the end.
+
+_unraisables: list[str] = []
+_orig_unraisablehook = sys.unraisablehook
+
+
+def _unraisablehook(unraisable: Any) -> None:
+    msg = unraisable.err_msg or f"Exception ignored in: {unraisable.object!r}"
+    tb = "".join(
+        traceback.format_exception(
+            unraisable.exc_type, unraisable.exc_value, unraisable.exc_traceback
+        )
+    )
+    _unraisables.append(f"{msg}\n{tb}")
+    _orig_unraisablehook(unraisable)
+
+
+async def main() -> None:
+    log_file = pathlib.Path(tempfile.mkdtemp()) / "activity_log.txt"
+    # In-process workers (worker2 below, plus the happy-path worker)
+    # share this module's ``LOGGED_ACTIVITIES``, which look at this env
+    # var to decide whether to log. Set it for the whole run.
+    os.environ["DURABILITY_ACTIVITY_LOG"] = str(log_file)
+
+    print("Starting embedded Temporal dev server...")
+    async with await temporalio.testing.WorkflowEnvironment.start_local() as env:
+        client = env.client
+
+        wid = await test_happy_path(client, log_file)
+        await test_replay_determinism(client, wid)
+        await test_activity_caching(env, client, log_file)
+
+    print("\nAll durability checks passed.")
+
+
+if __name__ == "__main__":
+    sys.unraisablehook = _unraisablehook
+    try:
+        asyncio.run(main())
+    except AssertionError as exc:
+        print(f"\nFAIL: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    # Some unraisable closures fire only during interpreter-shutdown
+    # GC. Force a collection now so any such closures land while we
+    # still control the exit code.
+    gc.collect()
+
+    if _unraisables:
+        print(
+            f"\nFAIL: {len(_unraisables)} unraisable exception(s) during run",
+            file=sys.stderr,
+        )
+        sys.exit(1)

--- a/examples/temporal-direct/uv.lock
+++ b/examples/temporal-direct/uv.lock
@@ -769,7 +769,7 @@ requires-dist = [
 
 [[package]]
 name = "temporalio"
-version = "1.25.0"
+version = "1.27.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nexus-rpc" },
@@ -777,13 +777,13 @@ dependencies = [
     { name = "types-protobuf" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/de/9c/3782bab0bf11a40b550147c19a5d1a476c17405391751982408902d9f138/temporalio-1.25.0.tar.gz", hash = "sha256:a3bbec1dcc904f674402cfa4faae480fda490b1c53ea5440c1f1996c562016fb", size = 2152534, upload-time = "2026-04-08T18:53:55.388Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/a1/6d59768d97ebb03676a33d10fec22a12ba6e7062801adc5946aa99138431/temporalio-1.27.0.tar.gz", hash = "sha256:fb92ae1077967ec626375a034af7e7108fe65f7b4ab1d98798ac2eecab247a65", size = 2497835, upload-time = "2026-04-30T22:39:56.305Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/19/e3/5676dd10d1164b6d6ca8752314054097b89c5da931e936af402a7b15236c/temporalio-1.25.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:6dc1bc8e1773b1a833d86a7ede2dd90ef4e031ced5b748b59e7f09a5bf9b327d", size = 13943906, upload-time = "2026-04-08T18:53:30.022Z" },
-    { url = "https://files.pythonhosted.org/packages/89/50/7cbf7f845973be986ec165348f72f7a409750842a04d554965a39be5cb4f/temporalio-1.25.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:3c8fdcf79ea5ae8ae2cf6f48072e4a86c3e0f4778f6a8a066c6ff1d336587db4", size = 13298719, upload-time = "2026-04-08T18:53:35.95Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/31/d474bab8535552add6ed289911bf1ffae5d7071823ece1069842190fcaed/temporalio-1.25.0-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:141f37aaafd7d090ba5c8776e4e9bc60df1fbc64b9f50c8f00e905a436588ddc", size = 13555435, upload-time = "2026-04-08T18:53:41.36Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/c8/e7dc053d6107bf2a037a3c9fe7b86639a25dcb888bde0e1ca366901ee47f/temporalio-1.25.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ff7ca5bb80264976477d4dc7a839b3d22af8577ae92306526a061481db49bf92", size = 14052050, upload-time = "2026-04-08T18:53:46.44Z" },
-    { url = "https://files.pythonhosted.org/packages/08/70/9340ed3a578321cbc153041d34834bb1ec3f1f3e3d9cded47cd1b7c3e403/temporalio-1.25.0-cp310-abi3-win_amd64.whl", hash = "sha256:9411534279a2e64847231b6059c214bff4d57cfd1532bd09f333d0b1603daa7f", size = 14299684, upload-time = "2026-04-08T18:53:52.482Z" },
+    { url = "https://files.pythonhosted.org/packages/60/07/6f2a59c250b1383f7da1a607cb03a9e7bc9bd9811ce8a4fdd4e951a334b4/temporalio-1.27.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:7daa4345b377b74602626326357c49ea1864bf1277fb7cb0b9f659f505c3dfb5", size = 14594920, upload-time = "2026-04-30T22:40:25.778Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/e2/16d881961ff4a8f64ab4205e5519ac6330e1cccc8c50808884e649bfc487/temporalio-1.27.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:17bed16eaf340dd48ad59178c3928ecf848674bce31f80529ea057848a29399b", size = 13940741, upload-time = "2026-04-30T22:40:35.578Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/bf/33c66ef5dcd5a63e5d4d171660e81302e4909545e6400e531d7d609d0a62/temporalio-1.27.0-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:449c1e4c0d4f4d6545442060b74760f491b67c075ebde6765be16468454e2874", size = 14238127, upload-time = "2026-04-30T22:40:46.198Z" },
+    { url = "https://files.pythonhosted.org/packages/db/5f/a8b7f9e26e6b7a1d0fa8e5e9e280fac3439114318fc0e65ae4c97905ebee/temporalio-1.27.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5302035f8c2fdadd69a1362309ea5514bb4129bd4e494e6b69f9a5bb85e8cb85", size = 14782764, upload-time = "2026-04-30T22:40:05.627Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/ba/9428864f1d79c92b1a2f987aab5ab8f57911c0deb8dcf738cb0d89556ed6/temporalio-1.27.0-cp310-abi3-win_amd64.whl", hash = "sha256:0f125e82ff616dd46fb45ac4d253319e989bf3734a4eb25af703d5bc27147af9", size = 14974832, upload-time = "2026-04-30T22:40:14.921Z" },
 ]
 
 [[package]]
@@ -861,7 +861,7 @@ wheels = [
 
 [[package]]
 name = "vercel-ai-sdk"
-version = "0.0.1.dev9"
+version = "0.0.1.dev10"
 source = { editable = "../../" }
 dependencies = [
     { name = "anthropic" },
@@ -884,6 +884,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "async-solipsism", specifier = ">=0.9" },
     { name = "mypy", specifier = ">=1.11" },
     { name = "pyright", specifier = ">=1.1.408" },
     { name = "pytest", specifier = ">=8.0" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ reportUnusedCallResult = false
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+testpaths = ["tests"]
 
 [tool.ruff]
 target-version = "py313"


### PR DESCRIPTION
Covers three scenarios that the example previously only demonstrated
by shape:

1. Happy path — runs end-to-end against an embedded dev server.
2. Replay determinism — fetches the recorded history and replays it
   through Replayer, catching any non-determinism in the loop.
3. Activity caching across worker restart — counts executions on each
   activity, kills the worker mid-flight, starts a fresh worker, and
   asserts that activities completed before the crash are served from
   history rather than re-run.

Also tweak temporal-direct to work with the new setups
