### PR TITLE
Add an AsyncIterableQueue to util

### DIFF
--- a/src/ai/agents/runtime.py
+++ b/src/ai/agents/runtime.py
@@ -7,6 +7,7 @@ import contextvars
 from collections.abc import AsyncGenerator, AsyncIterable, Awaitable
 from typing import Any
 
+from .. import util
 from ..types import events as events_
 from ..types import messages as messages_
 from . import hooks as hooks_
@@ -22,8 +23,8 @@ class Runtime:
     _SENTINEL = _Sentinel()
 
     def __init__(self) -> None:
-        self._event_queue: asyncio.Queue[events_.AgentEvent | Runtime._Sentinel] = (
-            asyncio.Queue()
+        self._event_queue: util.AsyncIterableQueue[events_.AgentEvent] = (
+            util.AsyncIterableQueue()
         )
         self._hook_labels: set[str] = set()
 
@@ -35,7 +36,7 @@ class Runtime:
         await self.put_event(events_.HookEvent(message=msg, hook=hook_part))
 
     async def signal_done(self) -> None:
-        await self._event_queue.put(self._SENTINEL)
+        await self._event_queue.astop()
 
     def track_hook_label(self, label: str) -> None:
         """Register a hook label for cleanup when the run ends."""
@@ -92,8 +93,5 @@ async def run(
     async with asyncio.TaskGroup() as tg:
         tg.create_task(_stop_when_done(rt, _drain()))
 
-        while True:
-            item = await rt._event_queue.get()
-            if isinstance(item, Runtime._Sentinel):
-                return
+        async for item in rt._event_queue:
             yield item

--- a/src/ai/util.py
+++ b/src/ai/util.py
@@ -19,6 +19,33 @@ class _Stop:
 _STOP = _Stop()
 
 
+class AsyncIterableQueue[T](asyncio.Queue[_Stop | T]):
+    """An asyncio.Queue that you can iterate over.
+
+    Call athrow or astop to stop it.
+    Can not be iterated on by multiple tasks!
+    """
+
+    def __init__(self, maxsize: int = 0) -> None:
+        super().__init__(maxsize)
+
+    async def __aiter__(self) -> AsyncIterator[T]:
+        while True:
+            el = await self.get()
+            if isinstance(el, _Stop):
+                if el.exception:
+                    raise el.exception
+                else:
+                    return
+            yield el
+
+    async def athrow(self, e: Exception) -> None:
+        await self.put(_Stop(exception=e))
+
+    async def astop(self) -> None:
+        await self.put(_STOP)
+
+
 @contextlib.asynccontextmanager
 async def unwrap_generator_exit() -> AsyncIterator[None]:
     """Convert a ``BaseExceptionGroup`` of only ``GeneratorExit``s into a single one.
@@ -75,7 +102,7 @@ async def decouple[T](
     generators are closed, so we should be OK.
 
     """
-    queue: asyncio.Queue[_Stop | T] = asyncio.Queue(size)
+    queue: AsyncIterableQueue[T] = AsyncIterableQueue(size)
 
     async def worker() -> None:
         async with maybe_aclosing(iter):
@@ -100,13 +127,7 @@ async def decouple[T](
         task = asyncio.create_task(worker())
 
     try:
-        while True:
-            el = await queue.get()
-            if isinstance(el, _Stop):
-                if el.exception:
-                    raise el.exception
-                else:
-                    return
+        async for el in queue:
             yield el
     finally:
         # cancel is a no-op if a task is already done or cancelled


### PR DESCRIPTION
We use the pattern in two places of emiting a sentinel into an async
queue to terminate iteration over it.  Make that properly supported.

(This is prompted by me also needing to do this in a third place
in an upcoming PR that I have decided is probably a mistake, but
this is still an improvement.)
