### PR TITLE
Get rid of interrupt_loop, require manually aborting hooks

### DIFF
--- a/examples/fastapi-vite/backend/agent.py
+++ b/examples/fastapi-vite/backend/agent.py
@@ -107,7 +107,6 @@ async def _execute_with_approval(tc: ai.ToolCall) -> ai.events.ToolCallResult:
             f"approve_{tc.id}",
             payload=ai.tools.ToolApproval,
             metadata={"tool_name": tc.name, "tool_kwargs": tc.kwargs},
-            interrupt_loop=True,
         )
     except ai.agents.hooks.HookPendingError as e:
         return ai.pending_tool_result(e.hook, tool_call_id=tc.id, tool_name=tc.name)

--- a/examples/fastapi-vite/backend/main.py
+++ b/examples/fastapi-vite/backend/main.py
@@ -65,7 +65,19 @@ async def chat(request: ChatRequest) -> fastapi.responses.StreamingResponse:
 
     async def stream_response() -> AsyncGenerator[str]:
         async with agent_.chat_agent.run(agent_.MODEL, messages) as result:
-            async for chunk in ai.agents.ui.ai_sdk.to_sse(result):
+            # We need to monitor the stream for HookEvents to abort;
+            # since ui.ai_sdk.to_sse consumes a stream, we have a wrapper
+            # async generator that does this check and yields the events.
+            async def process() -> AsyncGenerator[ai.events.AgentEvent]:
+                async for event in result:
+                    if (
+                        isinstance(event, ai.events.HookEvent)
+                        and event.hook.status == "pending"
+                    ):
+                        ai.agents.abort_pending_hook(event.hook)
+                    yield event
+
+            async for chunk in ai.agents.ui.ai_sdk.to_sse(process()):
                 yield chunk
 
     return fastapi.responses.StreamingResponse(

--- a/examples/samples/agent_hooks_serverless.py
+++ b/examples/samples/agent_hooks_serverless.py
@@ -1,12 +1,13 @@
-"""Serverless hook pattern: interrupt_loop=True.
+"""Serverless hook pattern.
 
 Demonstrates the serverless/stateless pattern where the agent run suspends
 cleanly when a hook has no resolution, then re-enters with a pre-registered
 resolution.
 
 Flow:
-  1. First run: hook fires, interrupt_loop=True cancels the future,
-     CancelledError is caught and the run ends.
+  1. First run: hook fires; the consumer sees the pending HookEvent and
+     calls abort_pending_hook(), which raises HookPendingError at the
+     awaiter so the gated tool short-circuits to a pending placeholder.
   2. Second run: resolve_hook() pre-registers the answer, agent.run()
      replays from the same input, and hook finds the resolution immediately.
 """
@@ -56,7 +57,6 @@ class GatedCall:
                 f"approve_{tc.id}",
                 payload=ai.tools.ToolApproval,
                 metadata={"tool": tc.name, "kwargs": tc.kwargs},
-                interrupt_loop=True,  # serverless: cancel if unresolved
             )
         except ai.agents.hooks.HookPendingError as e:
             return ai.pending_tool_result(e.hook, tool_call_id=tc.id, tool_name=tc.name)
@@ -121,6 +121,7 @@ async def main() -> None:
                     f"  Hook pending: {hook_part.hook_id} "
                     f"(metadata={hook_part.metadata})"
                 )
+                ai.agents.abort_pending_hook(hook_part)
 
         # Pick up the assistant turn that the loop appended so the
         # next run replays from the same point.
@@ -132,7 +133,7 @@ async def main() -> None:
     # -- Second run: pre-register resolution, replay from checkpoint --
     print("--- Run 2: pre-register approval, resume from checkpoint ---")
     for label in pending_hook_labels:
-        ai.resolve_hook(
+        ai.agents.resolve_hook(
             label, ai.tools.ToolApproval(granted=True, reason="user granted")
         )
 

--- a/src/ai/__init__.py
+++ b/src/ai/__init__.py
@@ -17,6 +17,7 @@ from .agents import (
     ToolCall,
     ToolCallLike,
     ToolRunner,
+    abort_pending_hook,
     agent,
     cancel_hook,
     hook,
@@ -117,6 +118,7 @@ __all__ = [
     "hook",
     "resolve_hook",
     "cancel_hook",
+    "abort_pending_hook",
     "TOOL_APPROVAL_HOOK_TYPE",
     # Middleware
     "Middleware",

--- a/src/ai/agents/__init__.py
+++ b/src/ai/agents/__init__.py
@@ -24,6 +24,7 @@ from .agent import (
 )
 from .hooks import (
     TOOL_APPROVAL_HOOK_TYPE,
+    abort_pending_hook,
     cancel_hook,
     hook,
     resolve_hook,
@@ -47,6 +48,7 @@ __all__ = [
     "ToolRunner",
     "StreamingStatusTool",
     "TOOL_APPROVAL_HOOK_TYPE",
+    "abort_pending_hook",
     "agent",
     "cancel_hook",
     "hook",

--- a/src/ai/agents/hooks.py
+++ b/src/ai/agents/hooks.py
@@ -14,15 +14,6 @@ Cancellation::
 
     await cancel_hook("approve_delete", reason="denied")
 
-Behavior depends on ``interrupt_loop``:
-
-interrupt_loop=False (default, long-running): the await blocks until
-resolve_hook() is called from outside (e.g. websocket handler, API endpoint).
-
-interrupt_loop=True (serverless): if no resolution is available, the
-hook's future is cancelled. The branch receives CancelledError and dies
-cleanly. On re-entry, call resolve_hook() before agent.run() to
-pre-register the resolution.
 """
 
 from __future__ import annotations
@@ -60,7 +51,7 @@ _live_hooks: dict[
     str, tuple[asyncio.Future[dict[str, Any]], dict[str, Any], runtime_.Runtime]
 ] = {}
 
-_pending_resolutions: dict[str, dict[str, Any]] = {}
+_pending_resolutions: dict[str, dict[str, Any] | BaseException] = {}
 
 
 class HookPendingError(Exception):
@@ -88,7 +79,6 @@ async def hook[T: pydantic.BaseModel](
     *,
     payload: type[T],
     metadata: dict[str, Any] | None = None,
-    interrupt_loop: bool = False,
 ) -> T:
     """Create a hook suspension point and await its resolution.
 
@@ -99,17 +89,11 @@ async def hook[T: pydantic.BaseModel](
         metadata: Arbitrary metadata surfaced in the pending signal message
             and checkpoint.  Useful for UI rendering (e.g. which tool needs
             approval, what arguments it received).
-        interrupt_loop: When ``True`` (serverless mode), the hook's future
-            is cancelled if no resolution is available, causing
-            ``CancelledError`` in the awaiting coroutine.  When ``False``
-            (long-running mode), the future is held until resolved
-            externally.
     """
     call = middleware_.HookContext(
         label=label,
         payload=payload,
         metadata=metadata or {},
-        interrupt_loop=interrupt_loop,
     )
 
     chain = middleware_._build_hook_chain(_hook_impl)
@@ -123,11 +107,12 @@ async def _hook_impl(call: middleware_.HookContext) -> pydantic.BaseModel:
     label = call.label
     payload = call.payload
     hook_metadata = call.metadata
-    interrupt_loop = call.interrupt_loop
 
     # Pre-registered resolution (serverless re-entry).
     pre_registered = _pending_resolutions.pop(label, None)
     if pre_registered is not None:
+        if isinstance(pre_registered, BaseException):
+            raise pre_registered
         return payload(**pre_registered)
 
     # No resolution available — suspend.
@@ -145,13 +130,6 @@ async def _hook_impl(call: middleware_.HookContext) -> pydantic.BaseModel:
     )
 
     await rt.put_hook(hook_part)
-
-    if interrupt_loop:
-        # Yield control so the consumer can see the pending message (??),
-        # then signal a hook error.
-        await asyncio.sleep(0)
-        if not future.done():
-            future.set_exception(HookPendingError(hook_part))
 
     # Await resolution — may be resolved externally or cancelled.
     resolution = await future
@@ -175,7 +153,7 @@ async def _hook_impl(call: middleware_.HookContext) -> pydantic.BaseModel:
 
 def resolve_hook(
     label: str,
-    data: pydantic.BaseModel | dict[str, Any],
+    data: pydantic.BaseModel | dict[str, Any] | BaseException,
     *,
     payload: type[pydantic.BaseModel] | None = None,
 ) -> None:
@@ -192,14 +170,22 @@ def resolve_hook(
        replay, it finds the pre-registered value and returns without
        suspending.
 
+    Passing an exception sends it to the awaiter (or stashes it for the
+    next replay) so the awaiting ``ai.hook(...)`` call raises rather than
+    returns.  See :func:`abort_pending_hook` for the common case of
+    propagating a :class:`HookPendingError`.
+
     Args:
         label: The hook label to resolve.
-        data: Resolution data — a dict or pydantic model instance.
-        payload: Optional pydantic model class for validation.  When
-            omitted and *data* is a model instance, its type is used.
+        data: Resolution data — a dict, pydantic model instance, or an
+            exception to raise in the awaiter.
+        payload: Optional pydantic model class for validation.  Ignored
+            when *data* is an exception.
     """
-    # Normalize to dict.
-    if isinstance(data, pydantic.BaseModel):
+    resolution: dict[str, Any] | BaseException
+    if isinstance(data, BaseException):
+        resolution = data
+    elif isinstance(data, pydantic.BaseModel):
         resolution = data.model_dump()
     elif isinstance(data, dict):
         if payload is not None:
@@ -214,11 +200,26 @@ def resolve_hook(
     # Path 1: live hook — resolve the future directly.
     if label in _live_hooks:
         future, _, _rt = _live_hooks[label]
-        future.set_result(resolution)
+        if isinstance(resolution, BaseException):
+            future.set_exception(resolution)
+        else:
+            future.set_result(resolution)
         return
 
     # Path 2: no live hook — pre-register for later consumption.
     _pending_resolutions[label] = resolution
+
+
+def abort_pending_hook(hook_part: messages_.HookPart[Any]) -> None:
+    """Abort the hook identified by ``hook_part.hook_id`` with a
+    :class:`HookPendingError` carrying *hook_part*.
+
+    Convenience wrapper around :func:`resolve_hook` for the serverless
+    pattern where a caller has a :class:`~ai.messages.HookPart` (e.g.
+    from inbound conversion) and needs to surface it back through the
+    awaiting ``ai.hook(...)`` site as a structured suspension.
+    """
+    resolve_hook(hook_part.hook_id, HookPendingError(hook_part))
 
 
 async def cancel_hook(label: str, *, reason: str | None = None) -> None:

--- a/src/ai/agents/middleware.py
+++ b/src/ai/agents/middleware.py
@@ -96,7 +96,6 @@ class HookContext:
     label: str
     payload: type[pydantic.BaseModel]
     metadata: dict[str, Any]
-    interrupt_loop: bool
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "metadata", dict(self.metadata))

--- a/src/ai/types/tools.py
+++ b/src/ai/types/tools.py
@@ -6,19 +6,7 @@ import pydantic
 
 
 class ToolApproval(pydantic.BaseModel):
-    """Payload schema for tool-approval hooks.
-
-    Usage inside a loop::
-
-        approval = await hook(
-            f"approve_{tc.tool_call_id}",
-            payload=ToolApproval,
-            metadata={"tool_name": tc.tool_name},
-            interrupt_loop=True,
-        )
-        if approval.granted:
-            ...
-    """
+    """Payload schema for tool-approval hooks."""
 
     granted: bool
     reason: str | None = None

--- a/tests/agents/test_hooks.py
+++ b/tests/agents/test_hooks.py
@@ -181,7 +181,6 @@ async def test_hook_metadata_in_pending() -> None:
                     "meta_test",
                     payload=Confirmation,
                     metadata={"tool": "rm -rf", "path": "/"},
-                    interrupt_loop=True,
                 )
             except ai.agents.hooks.HookPendingError:
                 return
@@ -194,6 +193,8 @@ async def test_hook_metadata_in_pending() -> None:
         async for event in stream:
             if isinstance(event, agent_events_.HookEvent):
                 hooks.append(event.hook)
+                if event.hook.status == "pending":
+                    ai.abort_pending_hook(event.hook)
 
     assert len(hooks) >= 1
     assert hooks[0].metadata == {"tool": "rm -rf", "path": "/"}

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -98,7 +98,6 @@ async def test_wrap_hook_is_called() -> None:
     assert len(hook_calls) == 1
     assert hook_calls[0].label == "test_hook"
     assert hook_calls[0].payload is Confirmation
-    assert hook_calls[0].interrupt_loop is False
 
 
 # ── wrap_agent_run ──────────────────────────────────────────────


### PR DESCRIPTION
Get rid of interrupt_loop, which forces knowledge of whether
serverless mode is being used inside the "agent application", and
instead require the consumer to abort pending hooks.

I don't think this turned out very well, though. I think it's kind of
clunky in general and the case of streaming the ui out is even
clunkier. (Though this version is actually much nicer than earlier
attempts! It wound up not actually needing AsyncIterableQueue.)
