### PR TITLE
Instead of using interrupt_loop, add abort_pending_hooks to run

### DIFF
--- a/examples/fastapi-vite/backend/agent.py
+++ b/examples/fastapi-vite/backend/agent.py
@@ -106,7 +106,6 @@ async def _execute_with_approval(tc: ai.ToolCall) -> ai.events.ToolCallResult:
             f"approve_{tc.id}",
             payload=ai.tools.ToolApproval,
             metadata={"tool_name": tc.name, "tool_kwargs": tc.kwargs},
-            interrupt_loop=True,
         )
     except ai.agents.hooks.HookPendingError as e:
         return ai.pending_tool_result(e.hook, tool_call_id=tc.id, tool_name=tc.name)

--- a/examples/fastapi-vite/backend/main.py
+++ b/examples/fastapi-vite/backend/main.py
@@ -64,7 +64,9 @@ async def chat(request: ChatRequest) -> fastapi.responses.StreamingResponse:
     ai.agents.ui.ai_sdk.apply_approvals(approvals)
 
     async def stream_response() -> AsyncGenerator[str]:
-        async with agent_.chat_agent.run(agent_.MODEL, messages) as result:
+        async with agent_.chat_agent.run(
+            agent_.MODEL, messages, abort_pending_hooks=True
+        ) as result:
             async for chunk in ai.agents.ui.ai_sdk.to_sse(result):
                 yield chunk
 

--- a/examples/samples/agent_hooks_serverless.py
+++ b/examples/samples/agent_hooks_serverless.py
@@ -1,12 +1,13 @@
-"""Serverless hook pattern: interrupt_loop=True.
+"""Serverless hook pattern: abort_pending_hooks=True.
 
 Demonstrates the serverless/stateless pattern where the agent run suspends
 cleanly when a hook has no resolution, then re-enters with a pre-registered
 resolution.
 
 Flow:
-  1. First run: hook fires, interrupt_loop=True cancels the future,
-     CancelledError is caught and the run ends.
+  1. First run: agent.run() is invoked with abort_pending_hooks=True, so
+     any hook without a pre-registered resolution raises HookPendingError;
+     the GatedCall wrapper catches it and emits a pending tool result.
   2. Second run: resolve_hook() pre-registers the answer, agent.run()
      replays from the same input, and hook finds the resolution immediately.
 """
@@ -56,7 +57,6 @@ class GatedCall:
                 f"approve_{tc.id}",
                 payload=ai.tools.ToolApproval,
                 metadata={"tool": tc.name, "kwargs": tc.kwargs},
-                interrupt_loop=True,  # serverless: cancel if unresolved
             )
         except ai.agents.hooks.HookPendingError as e:
             return ai.pending_tool_result(e.hook, tool_call_id=tc.id, tool_name=tc.name)
@@ -108,7 +108,7 @@ async def main() -> None:
     print("--- Run 1: hook fires, no resolution, run suspends ---")
     pending_hook_labels: list[str] = []
 
-    async with my_agent.run(model, messages) as stream:
+    async with my_agent.run(model, messages, abort_pending_hooks=True) as stream:
         async for event in stream:
             if isinstance(event, ai.events.TextDelta):
                 print(event.chunk, end="", flush=True)
@@ -137,7 +137,7 @@ async def main() -> None:
             label, ai.tools.ToolApproval(granted=True, reason="user granted")
         )
 
-    async with my_agent.run(model, messages) as stream:
+    async with my_agent.run(model, messages, abort_pending_hooks=True) as stream:
         async for event in stream:
             if isinstance(event, ai.events.TextDelta):
                 print(event.chunk, end="", flush=True)

--- a/src/ai/agents/agent.py
+++ b/src/ai/agents/agent.py
@@ -23,6 +23,7 @@ import pydantic
 from .. import models, types, util
 from ..types import builders
 from ..types import events as events_
+from . import hooks as hooks_
 from . import middleware as middleware_
 from . import runtime
 
@@ -911,6 +912,7 @@ class Agent:
         messages: list[types.messages.Message],
         *,
         middleware: list[middleware_.Middleware] | None = None,
+        abort_pending_hooks: bool = False,
     ) -> AsyncIterator[AgentStream]:
         """Run the agent loop, yielding events to the consumer.
 
@@ -928,6 +930,12 @@ class Agent:
             middleware: Optional list of middleware to apply to this run.
                 First in the list = outermost.  Middleware wraps model
                 calls, tool calls, hooks, and the run itself.
+            abort_pending_hooks: Default value of ``interrupt_loop`` for
+                ``ai.hook()`` calls made during this run.  ``True`` puts
+                the run in serverless mode: any hook without a
+                pre-registered resolution raises ``HookPendingError``.
+                Individual ``hook()`` calls can override by passing an
+                explicit ``interrupt_loop`` argument.
 
         To attribute a sub-agent's events to a branch, wrap the run in
         ``yield_from(..., label=...)`` — the label flows via
@@ -974,7 +982,11 @@ class Agent:
                 if mw_token is not None:
                     middleware_.deactivate(mw_token)
 
-        yield AgentStream(_stream(), context)
+        token = hooks_.abort_pending_hooks.set(abort_pending_hooks)
+        try:
+            yield AgentStream(_stream(), context)
+        finally:
+            hooks_.abort_pending_hooks.reset(token)
 
 
 def agent(

--- a/src/ai/agents/hooks.py
+++ b/src/ai/agents/hooks.py
@@ -16,18 +16,23 @@ Cancellation::
 
 Behavior depends on ``interrupt_loop``:
 
-interrupt_loop=False (default, long-running): the await blocks until
+interrupt_loop=False (long-running): the await blocks until
 resolve_hook() is called from outside (e.g. websocket handler, API endpoint).
 
 interrupt_loop=True (serverless): if no resolution is available, the
-hook's future is cancelled. The branch receives CancelledError and dies
-cleanly. On re-entry, call resolve_hook() before agent.run() to
-pre-register the resolution.
+hook raises ``HookPendingError`` in the awaiting coroutine.  On re-entry,
+call resolve_hook() before agent.run() to pre-register the resolution.
+
+interrupt_loop=None (default): defer to the ``abort_pending_hooks``
+contextvar, which ``Agent.run`` sets from its kwonly param of the same
+name.  This lets a caller flip the whole run into serverless mode
+without touching individual hook sites.
 """
 
 from __future__ import annotations
 
 import asyncio
+import contextvars
 from typing import Any
 
 import pydantic
@@ -62,6 +67,13 @@ _live_hooks: dict[
 
 _pending_resolutions: dict[str, dict[str, Any]] = {}
 
+# Per-run default for ``interrupt_loop``.  Set by ``Agent.run`` via its
+# ``abort_pending_hooks`` kwonly param.  ``hook()`` reads this when its
+# own ``interrupt_loop`` argument is None.
+abort_pending_hooks: contextvars.ContextVar[bool] = contextvars.ContextVar(
+    "abort_pending_hooks", default=False
+)
+
 
 class HookPendingError(Exception):
     """Exception for aborting due to a hook"""
@@ -88,7 +100,7 @@ async def hook[T: pydantic.BaseModel](
     *,
     payload: type[T],
     metadata: dict[str, Any] | None = None,
-    interrupt_loop: bool = False,
+    interrupt_loop: bool | None = None,
 ) -> T:
     """Create a hook suspension point and await its resolution.
 
@@ -99,12 +111,15 @@ async def hook[T: pydantic.BaseModel](
         metadata: Arbitrary metadata surfaced in the pending signal message
             and checkpoint.  Useful for UI rendering (e.g. which tool needs
             approval, what arguments it received).
-        interrupt_loop: When ``True`` (serverless mode), the hook's future
-            is cancelled if no resolution is available, causing
-            ``CancelledError`` in the awaiting coroutine.  When ``False``
-            (long-running mode), the future is held until resolved
-            externally.
+        interrupt_loop: When ``True`` (serverless mode), the hook raises
+            ``HookPendingError`` if no resolution is available.  When
+            ``False`` (long-running mode), the future is held until
+            resolved externally.  When ``None`` (default), the value is
+            taken from the ``abort_pending_hooks`` contextvar, which
+            ``Agent.run`` sets from its kwonly param of the same name.
     """
+    if interrupt_loop is None:
+        interrupt_loop = abort_pending_hooks.get()
     call = middleware_.HookContext(
         label=label,
         payload=payload,

--- a/src/ai/types/tools.py
+++ b/src/ai/types/tools.py
@@ -6,19 +6,7 @@ import pydantic
 
 
 class ToolApproval(pydantic.BaseModel):
-    """Payload schema for tool-approval hooks.
-
-    Usage inside a loop::
-
-        approval = await hook(
-            f"approve_{tc.tool_call_id}",
-            payload=ToolApproval,
-            metadata={"tool_name": tc.tool_name},
-            interrupt_loop=True,
-        )
-        if approval.granted:
-            ...
-    """
+    """Payload schema for tool-approval hooks."""
 
     granted: bool
     reason: str | None = None

--- a/tests/agents/test_hooks.py
+++ b/tests/agents/test_hooks.py
@@ -179,14 +179,15 @@ async def test_hook_metadata_in_pending() -> None:
                 "meta_test",
                 payload=Confirmation,
                 metadata={"tool": "rm -rf", "path": "/"},
-                interrupt_loop=True,
             )
         except ai.agents.hooks.HookPendingError:
             return
 
     mock_llm([[text_msg("OK")]])
     hooks: list[ai.messages.HookPart[Any]] = []
-    async with my_agent.run(MOCK_MODEL, [ai.user_message("go")]) as stream:
+    async with my_agent.run(
+        MOCK_MODEL, [ai.user_message("go")], abort_pending_hooks=True
+    ) as stream:
         async for event in stream:
             if isinstance(event, agent_events_.HookEvent):
                 hooks.append(event.hook)


### PR DESCRIPTION
Currently `interrupt_loop` still exists and uses
`abort_pending_hooks`'s value as a default, though maybe that's not
worth supporting?

I think this is probably nicer than #104.
