### PR TITLE
Add missing fastapi-vite shadcn utils.ts

### DIFF
--- a/examples/fastapi-vite/frontend/src/lib/utils.ts
+++ b/examples/fastapi-vite/frontend/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}


### PR DESCRIPTION
Silently dropped by the unanchored `lib/` gitignore rule when the
example was originally ported. PR #112 fixed the rule and re-added
the docs copy but missed this one; every shadcn component under
frontend/src/components imports `cn` from it, so a fresh clone
would fail to build.
