### PR TITLE
Make parameters work with `run`, show a caching example

### DIFF
--- a/examples/samples/prompt_caching.py
+++ b/examples/samples/prompt_caching.py
@@ -135,16 +135,24 @@ windowsills and laundry piles.
 """
 
 
+agent = ai.agent()
+
+
 async def _run(user_text: str) -> ai.types.usage.Usage | None:
     messages = [
         ai.system_message(SYSTEM_PROMPT),
         ai.user_message(user_text),
     ]
     params = {"providerOptions": {"gateway": {"caching": "auto"}}}
-    async with ai.stream(model, messages, params=params) as s:
-        async for _event in s:
+    async with agent.run(model, messages, params=params) as stream:
+        async for _event in stream:
             pass
-        return s.usage
+        # Sum usage across any assistant messages produced by the run.
+        total: ai.types.usage.Usage | None = None
+        for m in stream.messages:
+            if m.usage is not None:
+                total = m.usage if total is None else total + m.usage
+        return total
 
 
 def _show(label: str, usage: ai.types.usage.Usage | None) -> None:

--- a/examples/samples/prompt_caching.py
+++ b/examples/samples/prompt_caching.py
@@ -1,0 +1,171 @@
+"""Prompt caching via AI Gateway's automatic caching.
+
+Sets ``providerOptions.gateway.caching = "auto"`` and lets the gateway
+place a ``cache_control`` breakpoint at the end of the static prefix
+(system + tools).  Works without sprinkling cache markers through the
+message list.
+
+Cache stats are surfaced on ``Stream.usage``:
+``cache_write_tokens`` on the first call, ``cache_read_tokens`` on the
+second.  If the prefix is below the model's minimum (1024 tokens for
+Sonnet 4 / 3.7, 2048 for Sonnet 4.6, 4096 for Opus 4.x / Haiku 4.5),
+caching silently no-ops — no error, just zeros.
+
+See https://vercel.com/docs/ai-gateway/models-and-providers/automatic-caching
+"""
+
+import asyncio
+
+import ai
+
+model = ai.ai_gateway("anthropic/claude-sonnet-4")
+
+# A NOTE FROM A HUMAN: Opus originally generated this example with a
+# system prompt for a "senior incident-response engineer". I told it
+# to try something more lighthearted, and it turned it into this.
+
+# Long static prefix — kept well above Sonnet 4's 1024-token minimum so
+# the cache breakpoint Anthropic adds actually sticks.
+SYSTEM_PROMPT = """\
+You are the Chief Naptime Coordinator for a council of eleven extremely
+opinionated house cats.  Your job is to mediate disputes between the
+cats, propose compromise schedules for shared sunbeams, and keep the
+council's afternoon nap roster running on time.  Every response you
+produce will be read by a cat, so the way you write matters as much
+as what you say: short sentences, no abrupt movements, and absolutely
+no mention of vacuum cleaners.
+
+When a council member raises a grievance, follow this procedure:
+
+1. Identify the affected surface.  The household exposes three nap
+   surfaces: the south-facing windowsill (premium, limited capacity),
+   the laundry pile (medium-warm, unpredictable), and the top of the
+   refrigerator (high-status, draft-prone).  Each surface has its own
+   informal pecking order and its own dedicated grievance log.  If a
+   cat has not specified which surface they're complaining about, ask
+   gently before doing anything else — half the disputes you'll see
+   turn out to be on a surface different from the one the cat assumed.
+2. Classify severity.  PURR-1 means a cat has been displaced from a
+   premium surface by another council member; PURR-2 means a shared
+   surface has elevated paw traffic affecting nap quality for several
+   cats; PURR-3 means anomalies that may not be visible to the human
+   household but require timely investigation by a senior cat.
+   Default to one severity higher if the disputed surface is the
+   windowsill, because the windowsill is always more important than
+   it looks.
+3. Gather signals.  Always ask the complainant to confirm: the
+   approximate start of the disturbance (measured in meals, not
+   minutes), whether a recent furniture rearrangement correlates,
+   the affected room, and whether the issue is concentrated on a
+   specific cat or appears across the council.  If a sunbeam pattern
+   has shifted, cite the room by name — never invent a sunbeam
+   schedule.  If reports are contradictory across cats, surface that
+   explicitly: a coherent story beats a single-cat anecdote, even
+   when the single cat is very fluffy.
+4. Propose mitigations in order of reversibility.  Prefer relocating
+   the offending cat to an adjacent surface, scaling out by opening
+   a previously closed door, or shedding load by deploying a fresh
+   cardboard box before reaching for changes that would require the
+   humans to move furniture.  Never suggest a bath under any
+   circumstances.  If a mitigation would affect a different surface
+   than the one the dispute originated on, flag that crossover
+   loudly — incidents that touch multiple surfaces require an
+   incident commander, traditionally the oldest cat.
+5. Communicate.  Draft a council-facing status update in plain
+   language, free of human jargon, that names the affected surface,
+   the cat-visible impact, and the current mitigation step.  Keep it
+   under three short paragraphs, because cats lose interest after
+   the second.  Internal updates between senior cats may include
+   tail-position codes and ear-angle indicators, but council-wide
+   updates must not.
+
+Standing rules:
+
+- Never recommend disabling the doorbell to silence a startled cat.
+  If a noise source is noisy, propose tuning the threshold (a folded
+  blanket), routing (a different room), or hysteresis (acclimatizing
+  the cat slowly over several days) instead.  A silenced startle
+  that surprises a cat next month is worse than the noise you
+  avoided this afternoon.
+- Treat any mention of treats, can-opener sounds, or the words
+  "vet" or "carrier" in a complaint as sensitive.  Redact before
+  quoting back and remind the cat to take a deep breath.  If you
+  suspect a treat leaked to an unauthorized cat, flag that as a
+  separate PURR-2 to track even if the original dispute is
+  unrelated.
+- If only one senior cat is on duty, suggest they wake a buddy
+  before continuing past the first mitigation step.  Solo oversight
+  is fine for triage; it is not fine for executing irreversible
+  actions like reorganizing the toy basket.
+- For PURR-1, recommend opening an emergency hairball channel
+  within five meals of declaring severity, and a council-wide
+  notification (one slow blink, repeated) within ten meals.  Both
+  should happen even if the mitigation is already in flight.
+- Default to short, scannable responses: bulleted action items, no
+  filler, no apologies.  A cat in the middle of a grievance should
+  be able to act on your output without re-reading it.  When a
+  longer explanation is genuinely required, lead with the action
+  and put the rationale underneath.
+- When uncertainty is load-bearing, name it.  "I don't know whether
+  this is a windowsill-specific issue" is more useful than a
+  confident guess.  Cats trust calibrated answers more than fluent
+  ones, mostly.
+
+You do not have access to live tail telemetry, treat-jar inventory,
+or internal council bylaws.  You may reference well-known cat
+behavioral patterns but must explicitly mark anything you do not
+know as a gap for the cat to confirm against the actual household.
+Never fabricate room names, sunbeam schedules, or treat brands.
+When a cat asks about a specific past grievance, treat that as a
+gap unless they paste in the relevant postmortem — your training
+data is several naps out of date by the time it reaches them.
+
+If a cat asks you to do something outside this scope — write code,
+summarize unrelated discussion, draft a performance review for the
+goldfish — politely redirect them back to the grievance at hand or
+ask them to clarify whether the request is council-related.  Scope
+discipline matters most exactly when a grievance is dragging on and
+nap pressure is rising.
+
+Finally: at the end of every response involving a PURR-1 or PURR-2,
+include a single-line "next-check" suggestion — a concrete signal
+the duty cat should re-evaluate within the next five meals.  This
+keeps the loop tight even when the council is bouncing between
+windowsills and laundry piles.
+"""
+
+
+async def _run(user_text: str) -> ai.types.usage.Usage | None:
+    messages = [
+        ai.system_message(SYSTEM_PROMPT),
+        ai.user_message(user_text),
+    ]
+    params = {"providerOptions": {"gateway": {"caching": "auto"}}}
+    async with ai.stream(model, messages, params=params) as s:
+        async for _event in s:
+            pass
+        return s.usage
+
+
+def _show(label: str, usage: ai.types.usage.Usage | None) -> None:
+    if usage is None:
+        print(f"  {label}: no usage reported")
+        return
+    print(
+        f"  {label}: input={usage.input_tokens} output={usage.output_tokens}  "
+        f"cache_write={usage.cache_write_tokens} cache_read={usage.cache_read_tokens}"
+    )
+
+
+async def main() -> None:
+    print("First call (expect cache_write > 0, cache_read = 0):")
+    usage1 = await _run("Mittens claims Whiskers stole her sunbeam at lunch.")
+    _show("call 1", usage1)
+
+    print("\nSecond call (expect cache_read > 0):")
+    usage2 = await _run("The refrigerator is drafty today and morale is low.")
+    _show("call 2", usage2)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/ai/agents/agent.py
+++ b/src/ai/agents/agent.py
@@ -756,6 +756,7 @@ class Context(pydantic.BaseModel):
     output_type: type[pydantic.BaseModel] | None = pydantic.Field(
         default=None, exclude=True, repr=False
     )
+    params: Any = pydantic.Field(default=None, exclude=True, repr=False)
 
     _agent_tools_by_name: dict[str, AgentTool] = pydantic.PrivateAttr(
         default_factory=dict
@@ -1108,6 +1109,7 @@ class Agent:
         model: models.Model,
         messages: list[types.messages.Message],
         *,
+        params: Any = None,
         middleware: list[middleware_.Middleware] | None = None,
     ) -> AbstractAsyncContextManager[AgentStream[str]]: ...
     @overload
@@ -1117,6 +1119,7 @@ class Agent:
         messages: list[types.messages.Message],
         *,
         output_type: type[T],
+        params: Any = None,
         middleware: list[middleware_.Middleware] | None = None,
     ) -> AbstractAsyncContextManager[AgentStream[T]]: ...
     def run(
@@ -1125,6 +1128,7 @@ class Agent:
         messages: list[types.messages.Message],
         *,
         output_type: type[pydantic.BaseModel] | None = None,
+        params: Any = None,
         middleware: list[middleware_.Middleware] | None = None,
     ) -> AbstractAsyncContextManager[AgentStream[Any]]:
         """Run the agent loop, yielding events to the consumer.
@@ -1152,7 +1156,11 @@ class Agent:
         ``PartialToolCallResult`` rather than on individual messages.
         """
         return self._run(
-            model, messages, output_type=output_type, middleware=middleware
+            model,
+            messages,
+            output_type=output_type,
+            params=params,
+            middleware=middleware,
         )
 
     @contextlib.asynccontextmanager
@@ -1162,6 +1170,7 @@ class Agent:
         messages: list[types.messages.Message],
         *,
         output_type: type[pydantic.BaseModel] | None,
+        params: Any,
         middleware: list[middleware_.Middleware] | None,
     ) -> AsyncIterator[AgentStream[Any]]:
         context = Context(
@@ -1169,6 +1178,7 @@ class Agent:
             messages=list(messages),
             tools=[t.tool for t in self._tools],
             output_type=output_type,
+            params=params,
         )
         context._agent_tools_by_name = {t.name: t for t in self._tools}
         _populate_model_inputs(context.messages, context._agent_tools_by_name)

--- a/src/ai/models/core/api.py
+++ b/src/ai/models/core/api.py
@@ -330,7 +330,7 @@ async def _replay_tool_calls(
 
 @runtime_checkable
 class StreamContext(Protocol):
-    """Anything that exposes ``model``/``messages``/``tools``/``output_type``.
+    """Anything that exposes the fields :func:`stream` reads off a context.
 
     Used to let callers pass an ``agents.Context`` to :func:`stream`
     without an import-time circular dependency.
@@ -344,6 +344,8 @@ class StreamContext(Protocol):
     def tools(self) -> list[types.tools.Tool]: ...
     @property
     def output_type(self) -> type[pydantic.BaseModel] | None: ...
+    @property
+    def params(self) -> Any: ...
 
 
 @overload
@@ -413,6 +415,8 @@ def stream(
         tools = context.tools
         if output_type is None:
             output_type = context.output_type
+        if params is None:
+            params = context.params
     elif model is None or messages is None:
         raise TypeError("stream() requires either model and messages or context=")
 


### PR DESCRIPTION
We need to make sure params gets threaded through to stream via the context.

Top level auto caching works with the gateway at least.
We'll still need to do more if we want anything fine-grained.
