### PR TITLE
One more (last?) round of tweaks on aggregators

### DIFF
--- a/skills/ai/SKILL.md
+++ b/skills/ai/SKILL.md
@@ -97,7 +97,7 @@ type Joined = Annotated[AsyncGenerator[str], ai.agents.Aggregate(ai.agents.Conca
 
 Or pass the factory as a keyword argument: `@ai.tool(aggregator=ai.agents.LastAggregator)`. Specifying both an annotation marker and the kwarg raises `TypeError`.
 
-Built-in aggregators: `ai.agents.ConcatAggregator`, `ai.agents.LastAggregator`, `ai.agents.MessageAggregator`. Subclass `ai.agents.SimpleAggregator[Item, Result]` (in/out same type) or `ai.events.Aggregator[Item, Result, ModelResult]` (separate model output) for custom ones.
+Built-in aggregators: `ai.agents.ConcatAggregator`, `ai.agents.LastAggregator`, `ai.agents.MessageAggregator`. Subclass `ai.agents.SimpleAggregator[Item, Result]` (in/out same type) or `ai.events.Aggregator[Item, Result, ModelInput]` (separate model input) for custom ones.
 
 ## Custom agent loops
 

--- a/src/ai/agents/agent.py
+++ b/src/ai/agents/agent.py
@@ -159,12 +159,12 @@ def _populate_model_inputs(
             agg_cls = _aggregator_cls(tool.aggregator)
             if agg_cls is None:
                 continue
-            part.set_model_input(agg_cls.to_model_output(part.result))
+            part.set_model_input(agg_cls.to_model_input(part.result))
 
 
 class SimpleAggregator[Item, Result](events_.Aggregator[Item, Result, Result]):
     @classmethod
-    def to_model_output(cls, snapshot: Result) -> Result:
+    def to_model_input(cls, snapshot: Result) -> Result:
         return snapshot
 
 
@@ -214,7 +214,9 @@ class MessageAggregator(events_.Aggregator[events_.AgentEvent, MessageBundle, st
         return MessageBundle(messages=tuple(self._messages))
 
     @classmethod
-    def to_model_output(cls, snapshot: MessageBundle) -> str:
+    def to_model_input(cls, snapshot: MessageBundle | Any) -> str:
+        if not isinstance(snapshot, MessageBundle):
+            snapshot = MessageBundle.model_validate(snapshot)
         for m in reversed(snapshot.messages):
             if m.role == "assistant" and m.text:
                 return m.text
@@ -552,7 +554,7 @@ class ToolCall:
                         aggregator=tool.aggregator,
                     )
                     result = agg.snapshot()
-                    model_input = agg.get_model_output()
+                    model_input = agg.get_model_input()
                 else:
                     result = await tool.fn(**kwargs)
                     model_input = result
@@ -1017,7 +1019,7 @@ async def yield_from[T, S, R](
         tool_call_id=tool_call_id,
         label=label,
     )
-    return agg.get_model_output()
+    return agg.get_model_input()
 
 
 async def _aggregate_from[T, S, R](

--- a/src/ai/types/events.py
+++ b/src/ai/types/events.py
@@ -264,24 +264,24 @@ async def replay_message_events(
 # ---------------------------------------------------------------------------
 
 
-class Aggregator[Item, Result, ModelResult]:
+class Aggregator[Item, Result, ModelInput]:
     @abc.abstractmethod
     def feed(self, item: Item) -> None: ...
 
     @abc.abstractmethod
     def snapshot(self) -> Result: ...
 
-    def get_model_output(self) -> ModelResult:
+    def get_model_input(self) -> ModelInput:
         """Return the model-facing value derived from this aggregator's state.
 
-        Default implementation defers to :meth:`to_model_output`; subclasses
+        Default implementation defers to :meth:`to_model_input`; subclasses
         with non-trivial state may override either or both.
         """
-        return type(self).to_model_output(self.snapshot())
+        return type(self).to_model_input(self.snapshot())
 
     @classmethod
     @abc.abstractmethod
-    def to_model_output(cls, snapshot: Result) -> ModelResult:
+    def to_model_input(cls, snapshot: Result) -> ModelInput:
         """Stateless conversion: snapshot -> model-facing value.
 
         Called on inbound (when a tool result round-trips back from the

--- a/src/ai/types/messages.py
+++ b/src/ai/types/messages.py
@@ -38,7 +38,7 @@ class ToolResultPart(pydantic.BaseModel):
     # Value the LLM sees on its next turn.  For most tools this is
     # identical to ``result``; for aggregator-backed tools (sub-agents,
     # streaming-text) it's derived from the aggregator's
-    # ``get_model_output``.  Not part of the wire model: it's populated
+    # ``get_model_input``.  Not part of the wire model: it's populated
     # by tool execution and by ``Agent.run`` (which has the tool
     # registry) rather than carried across serialization.  ``default_factory``
     # preserves singleton identity so the unset sentinel survives pydantic's


### PR DESCRIPTION
Rename to_model_output to be to_model_*input*, since it is the *input*
to the model. Also, for MessageAggregator, do a model_validate if it's
not a model.
