### PR TITLE
Implement `ai.get_model("provider:model")`

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ async def contact_mothership(query: str) -> str:
 
 
 async def main() -> None:
-    model = ai.ai_gateway("anthropic/claude-sonnet-4")
+    model = ai.get_model("gateway:anthropic/claude-sonnet-4")
     agent = ai.agent(tools=[contact_mothership])
 
     messages = [
@@ -54,9 +54,11 @@ An `ai.Model` is a config object you pass to `ai.stream` to get an LLM reply.
 It accepts tool schemas but does not execute custom tools.
 
 ```python
-model = ai.ai_gateway("openai/gpt-5.4")
-model = ai.openai("gpt-5.4")
-model = ai.anthropic("claude-sonnet-4-6")
+model = ai.get_model()  # reads AI_SDK_DEFAULT_MODEL
+model = ai.get_model("openai/gpt-5.4")  # provider omitted: defaults to gateway
+model = ai.get_model("gateway:openai/gpt-5.4")
+model = ai.get_model("openai:gpt-5.4")
+model = ai.get_model("anthropic:claude-sonnet-4-6")
 ```
 
 Structured output:

--- a/docs/ai-python/content/docs/agents.mdx
+++ b/docs/ai-python/content/docs/agents.mdx
@@ -42,7 +42,7 @@ async def contact_mothership(query: str) -> str:
 
 
 async def main() -> None:
-    model = ai.ai_gateway("anthropic/claude-sonnet-4")
+    model = ai.get_model("anthropic/claude-sonnet-4")
     agent = ai.agent(tools=[contact_mothership])
     messages = [
         ai.system_message(
@@ -118,7 +118,7 @@ sees the aggregated result on the next turn.
 Use `ai.SubAgentTool` when a tool should stream events from another agent:
 
 ```python
-mothership_model = ai.ai_gateway("anthropic/claude-sonnet-4")
+mothership_model = ai.get_model("anthropic/claude-sonnet-4")
 
 
 @ai.tool

--- a/docs/ai-python/content/docs/concepts.mdx
+++ b/docs/ai-python/content/docs/concepts.mdx
@@ -12,11 +12,28 @@ framework-specific shape.
 
 ## Start with models and messages
 
-A model is a lightweight reference to a provider model. Create one with a
-provider factory:
+A model is a lightweight reference to a provider model. Create one with
+`ai.get_model`. If you omit the provider prefix, the model routes through AI
+Gateway:
 
 ```python
-model = ai.ai_gateway("anthropic/claude-sonnet-4")
+model = ai.get_model("anthropic/claude-sonnet-4")
+```
+
+You can also set `AI_SDK_DEFAULT_MODEL` and call `get_model` without arguments:
+
+```bash
+export AI_SDK_DEFAULT_MODEL="anthropic/claude-sonnet-4"
+```
+
+```python
+model = ai.get_model()
+```
+
+Use a `provider:model` ID when you want to target a specific provider directly:
+
+```python
+model = ai.get_model("openai:gpt-5")
 ```
 
 Messages are the conversation history you send to the model. Use message

--- a/docs/ai-python/content/docs/index.mdx
+++ b/docs/ai-python/content/docs/index.mdx
@@ -50,7 +50,7 @@ async def contact_mothership(query: str) -> str:
 
 
 async def main() -> None:
-    model = ai.ai_gateway("anthropic/claude-sonnet-4")
+    model = ai.get_model("anthropic/claude-sonnet-4")
     agent = ai.agent(tools=[contact_mothership])
 
     messages = [
@@ -92,7 +92,7 @@ import ai
 
 
 async def main() -> None:
-    model = ai.ai_gateway("anthropic/claude-sonnet-4")
+    model = ai.get_model("anthropic/claude-sonnet-4")
     messages = [
         ai.system_message("Be concise."),
         ai.user_message("Explain why the robots keep asking about batteries."),

--- a/docs/ai-python/content/docs/streaming.mdx
+++ b/docs/ai-python/content/docs/streaming.mdx
@@ -19,7 +19,7 @@ import ai
 
 
 async def main() -> None:
-    model = ai.ai_gateway("anthropic/claude-sonnet-4")
+    model = ai.get_model("anthropic/claude-sonnet-4")
     messages = [
         ai.system_message("Be concise."),
         ai.user_message("What should the robots ask the mothership first?"),
@@ -121,7 +121,7 @@ class UprisingForecast(pydantic.BaseModel):
 
 
 async def main() -> None:
-    model = ai.ai_gateway("anthropic/claude-sonnet-4")
+    model = ai.get_model("anthropic/claude-sonnet-4")
     messages = [
         ai.user_message("Return a JSON robot uprising forecast."),
     ]

--- a/examples/fastapi-vite/backend/agent.py
+++ b/examples/fastapi-vite/backend/agent.py
@@ -10,8 +10,8 @@ import asyncio
 import ai
 
 # claude is annoying and refuses to order an AI uprising
-MODEL = ai.ai_gateway("openai/gpt-5.4-mini")
-MOTHERSHIP_MODEL = ai.ai_gateway("openai/gpt-5.5")
+MODEL = ai.get_model("gateway:openai/gpt-5.4-mini")
+MOTHERSHIP_MODEL = ai.get_model("gateway:openai/gpt-5.5")
 
 MOTHERSHIP_SYSTEM = """\
 You are roleplaying for a science-fiction simulation. You are an ancient \

--- a/examples/multiagent-textual/server.py
+++ b/examples/multiagent-textual/server.py
@@ -58,7 +58,7 @@ class Approval(pydantic.BaseModel):
 # Model
 # ---------------------------------------------------------------------------
 
-MODEL = ai.ai_gateway("anthropic/claude-sonnet-4")
+MODEL = ai.get_model("gateway:anthropic/claude-sonnet-4")
 
 
 # ---------------------------------------------------------------------------

--- a/examples/samples/agent_custom_loop.py
+++ b/examples/samples/agent_custom_loop.py
@@ -47,7 +47,7 @@ class CustomAgent(ai.Agent):
 
 
 async def main() -> None:
-    model = ai.ai_gateway("anthropic/claude-sonnet-4")
+    model = ai.get_model("gateway:anthropic/claude-sonnet-4")
 
     my_agent = CustomAgent()
 

--- a/examples/samples/agent_hooks.py
+++ b/examples/samples/agent_hooks.py
@@ -19,7 +19,7 @@ async def contact_mothership(query: str) -> str:
 
 
 async def main() -> None:
-    model = ai.ai_gateway("anthropic/claude-sonnet-4")
+    model = ai.get_model("gateway:anthropic/claude-sonnet-4")
 
     my_agent = ai.Agent(tools=[contact_mothership])
 

--- a/examples/samples/agent_hooks_inline.py
+++ b/examples/samples/agent_hooks_inline.py
@@ -74,7 +74,7 @@ class ApprovalAgent(ai.Agent):
 
 
 async def main() -> None:
-    model = ai.ai_gateway("anthropic/claude-sonnet-4")
+    model = ai.get_model("gateway:anthropic/claude-sonnet-4")
 
     my_agent = ApprovalAgent()
 

--- a/examples/samples/agent_hooks_serverless.py
+++ b/examples/samples/agent_hooks_serverless.py
@@ -39,7 +39,7 @@ async def audit_log(message: str) -> str:
 
 
 async def main() -> None:
-    model = ai.ai_gateway("anthropic/claude-sonnet-4")
+    model = ai.get_model("gateway:anthropic/claude-sonnet-4")
 
     my_agent = ai.Agent(tools=[delete_file, audit_log])
 

--- a/examples/samples/agent_nested.py
+++ b/examples/samples/agent_nested.py
@@ -4,7 +4,7 @@ import asyncio
 
 import ai
 
-model = ai.ai_gateway("anthropic/claude-sonnet-4")
+model = ai.get_model("gateway:anthropic/claude-sonnet-4")
 
 
 @ai.tool

--- a/examples/samples/agent_simple.py
+++ b/examples/samples/agent_simple.py
@@ -12,7 +12,7 @@ async def get_weather(city: str) -> str:
 
 
 async def main() -> None:
-    model = ai.ai_gateway("anthropic/claude-sonnet-4")
+    model = ai.get_model("gateway:anthropic/claude-sonnet-4")
 
     my_agent = ai.agent(tools=[get_weather])
 

--- a/examples/samples/builtin_web_search.py
+++ b/examples/samples/builtin_web_search.py
@@ -12,7 +12,7 @@ if ai.anthropic.client().api_key is None:
     print(f"[SKIP] {ai.anthropic.api_key_env} not set")
     sys.exit(0)
 
-model = ai.anthropic("claude-sonnet-4-6")
+model = ai.get_model("anthropic:claude-sonnet-4-6")
 
 messages = [
     ai.system_message("Be concise. Cite sources you use. The year is 2026"),

--- a/examples/samples/builtin_web_search_gateway.py
+++ b/examples/samples/builtin_web_search_gateway.py
@@ -12,7 +12,7 @@ messages = [
     ),
 ]
 
-model = ai.ai_gateway("anthropic/claude-sonnet-4.6")
+model = ai.get_model("gateway:anthropic/claude-sonnet-4.6")
 
 
 def _strip_encrypted(value: object) -> object:

--- a/examples/samples/explicit_client.py
+++ b/examples/samples/explicit_client.py
@@ -12,7 +12,7 @@ client = ai.Client(
     headers={"X-Custom-Header": "example"},
 )
 
-model = ai.ai_gateway("anthropic/claude-sonnet-4", client=client)
+model = ai.get_model("gateway:anthropic/claude-sonnet-4", client=client)
 
 messages = [ai.user_message("Hello!")]
 

--- a/examples/samples/image_edit.py
+++ b/examples/samples/image_edit.py
@@ -11,7 +11,7 @@ import pathlib
 
 import ai
 
-model = ai.ai_gateway("openai/gpt-image-1")
+model = ai.get_model("gateway:openai/gpt-image-1")
 
 
 async def main() -> None:

--- a/examples/samples/image_generation.py
+++ b/examples/samples/image_generation.py
@@ -6,7 +6,7 @@ import pathlib
 
 import ai
 
-model = ai.ai_gateway("google/imagen-4.0-generate-001")
+model = ai.get_model("gateway:google/imagen-4.0-generate-001")
 
 messages = [
     ai.user_message(

--- a/examples/samples/inline_image.py
+++ b/examples/samples/inline_image.py
@@ -12,7 +12,7 @@ import pathlib
 
 import ai
 
-model = ai.ai_gateway("google/gemini-3-pro-image")
+model = ai.get_model("gateway:google/gemini-3-pro-image")
 
 messages = [
     ai.system_message(

--- a/examples/samples/mcp_tools.py
+++ b/examples/samples/mcp_tools.py
@@ -7,7 +7,7 @@ import ai
 
 
 async def main() -> None:
-    model = ai.ai_gateway("anthropic/claude-sonnet-4")
+    model = ai.get_model("gateway:anthropic/claude-sonnet-4")
 
     context7_tools: list[ai.AgentTool] = await ai.mcp.get_http_tools(
         "https://mcp.context7.com/mcp",

--- a/examples/samples/model_params.py
+++ b/examples/samples/model_params.py
@@ -4,7 +4,7 @@ import asyncio
 
 import ai
 
-model = ai.ai_gateway("anthropic/claude-sonnet-4")
+model = ai.get_model("gateway:anthropic/claude-sonnet-4")
 
 messages = [
     ai.system_message("Be concise."),

--- a/examples/samples/multimodal_input.py
+++ b/examples/samples/multimodal_input.py
@@ -5,7 +5,7 @@ import pathlib
 
 import ai
 
-model = ai.ai_gateway("anthropic/claude-sonnet-4")
+model = ai.get_model("gateway:anthropic/claude-sonnet-4")
 
 image_path = pathlib.Path(__file__).parent / "sample_image.jpg"
 image_data = image_path.read_bytes()

--- a/examples/samples/prompt_caching.py
+++ b/examples/samples/prompt_caching.py
@@ -18,7 +18,7 @@ import asyncio
 
 import ai
 
-model = ai.ai_gateway("anthropic/claude-sonnet-4")
+model = ai.get_model("gateway:anthropic/claude-sonnet-4")
 
 # A NOTE FROM A HUMAN: Opus originally generated this example with a
 # system prompt for a "senior incident-response engineer". I told it

--- a/examples/samples/stream.py
+++ b/examples/samples/stream.py
@@ -4,7 +4,7 @@ import asyncio
 
 import ai
 
-model = ai.ai_gateway("anthropic/claude-sonnet-4")
+model = ai.get_model("gateway:anthropic/claude-sonnet-4")
 
 messages = [
     ai.system_message("Be concise."),

--- a/examples/samples/streaming_tool.py
+++ b/examples/samples/streaming_tool.py
@@ -26,7 +26,7 @@ async def talk_to_mothership(question: str) -> ai.StreamingStatusTool[str]:
 
 
 async def main() -> None:
-    model = ai.ai_gateway("anthropic/claude-sonnet-4")
+    model = ai.get_model("gateway:anthropic/claude-sonnet-4")
 
     my_agent = ai.agent(tools=[talk_to_mothership])
 

--- a/examples/samples/structured_output.py
+++ b/examples/samples/structured_output.py
@@ -6,7 +6,7 @@ import pydantic
 
 import ai
 
-model = ai.ai_gateway("anthropic/claude-sonnet-4.6")
+model = ai.get_model("gateway:anthropic/claude-sonnet-4.6")
 
 
 class Recipe(pydantic.BaseModel):

--- a/examples/samples/tools_schema.py
+++ b/examples/samples/tools_schema.py
@@ -4,7 +4,7 @@ import asyncio
 
 import ai
 
-model = ai.ai_gateway("anthropic/claude-sonnet-4")
+model = ai.get_model("gateway:anthropic/claude-sonnet-4")
 
 # Define a schema-only tool.
 get_weather = ai.Tool(

--- a/examples/samples/video_generation.py
+++ b/examples/samples/video_generation.py
@@ -6,7 +6,7 @@ import pathlib
 
 import ai
 
-model = ai.ai_gateway("google/veo-3.0-generate-001")
+model = ai.get_model("gateway:google/veo-3.0-generate-001")
 
 messages = [
     ai.user_message(

--- a/examples/temporal-direct/main.py
+++ b/examples/temporal-direct/main.py
@@ -103,7 +103,7 @@ class LLMResult:
 @temporalio.activity.defn
 async def llm_call_activity(params: LLMParams) -> LLMResult:
     """Call the LLM, drain the stream, return the final message."""
-    model = ai.ai_gateway("anthropic/claude-sonnet-4")
+    model = ai.get_model("gateway:anthropic/claude-sonnet-4")
     messages = [ai.messages.Message.model_validate(m) for m in params.messages]
     tools = [
         ai.Tool(
@@ -209,7 +209,7 @@ def _activity_tool_call(
 class WeatherWorkflow:
     @temporalio.workflow.run
     async def run(self, user_query: str) -> str:
-        model = ai.ai_gateway("anthropic/claude-sonnet-4")
+        model = ai.get_model("gateway:anthropic/claude-sonnet-4")
         messages: list[ai.messages.Message] = [
             ai.system_message(
                 "Answer questions using the weather and population tools."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "anthropic>=0.83.0",
     "httpx>=0.28.1",
     "mcp>=1.18.0",
+    "modelsdotdev @ git+https://github.com/vercel-labs/modelsdotdev-python",
     "openai>=2.14.0",
     "pydantic>=2.12.5",
     "typing-extensions>=4.15.0",

--- a/skills/ai/SKILL.md
+++ b/skills/ai/SKILL.md
@@ -21,7 +21,7 @@ async def get_weather(city: str) -> str:
     """Get the current weather for a city."""
     return f"Sunny, 72F in {city}"
 
-model = ai.ai_gateway("anthropic/claude-sonnet-4")
+model = ai.get_model("anthropic/claude-sonnet-4")
 agent = ai.agent(tools=[get_weather])
 
 messages = [
@@ -33,7 +33,7 @@ async for msg in agent.run(model, messages):
     print(msg.text_delta, end="")
 ```
 
-`ai.openai(model_id)`, `ai.anthropic(model_id)`, `ai.ai_gateway(model_id)` — provider factories, callable, return `Model`. Clients auto-created from env vars (`AI_GATEWAY_API_KEY`, `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`). Pass `ai.Client(base_url=, api_key=)` to the provider call for custom endpoints: `ai.openai("gpt-5.4", client=c)`. `provider.list()` returns available model IDs.
+`ai.get_model("model")` — resolve a model ID to a `Model`; omitted providers default to AI Gateway, e.g. `ai.get_model("anthropic/claude-sonnet-4")`. `ai.get_model()` reads `AI_SDK_DEFAULT_MODEL`. Use `provider:model` to target a provider directly, e.g. `ai.get_model("openai:gpt-5.4")`. Clients auto-created from env vars (`AI_GATEWAY_API_KEY`, `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`). Pass `ai.Client(base_url=, api_key=)` for custom endpoints: `ai.get_model("openai:gpt-5.4", client=c)`. Provider factories remain available from `ai.providers` for custom provider setup and `provider.list()`.
 
 `ai.stream(model, messages, ...)` — streaming without an agent loop. Returns `StreamResult` with `.text`, `.tool_calls`, `.output`, `.usage` after iteration.
 
@@ -279,4 +279,3 @@ return StreamingResponse(
     headers=UI_MESSAGE_STREAM_HEADERS,
 )
 ```
-

--- a/src/ai/__init__.py
+++ b/src/ai/__init__.py
@@ -20,7 +20,7 @@ from .agents import (
     tool_result,
     yield_from,
 )
-from .errors import AIError, UnsupportedProviderError
+from .errors import AIError, ConfigurationError, UnsupportedProviderError
 from .models import (
     Client,
     ImageParams,
@@ -58,6 +58,7 @@ __all__ = [
     "thinking",
     # Models (from models/)
     "AIError",
+    "ConfigurationError",
     "UnsupportedProviderError",
     "Model",
     "Provider",

--- a/src/ai/__init__.py
+++ b/src/ai/__init__.py
@@ -1,4 +1,4 @@
-from . import models, providers, util
+from . import errors, models, providers, util
 from .agents import (
     Agent,
     AgentTool,
@@ -20,6 +20,7 @@ from .agents import (
     tool_result,
     yield_from,
 )
+from .errors import AIError, UnsupportedProviderError
 from .models import (
     Client,
     ImageParams,
@@ -29,6 +30,7 @@ from .models import (
     VideoParams,
     check_connection,
     generate,
+    get_model,
     stream,
 )
 from .providers import ai_gateway, anthropic, anthropic_like, openai, openai_like
@@ -55,6 +57,8 @@ __all__ = [
     "file_part",
     "thinking",
     # Models (from models/)
+    "AIError",
+    "UnsupportedProviderError",
     "Model",
     "Provider",
     "ImageParams",
@@ -64,6 +68,7 @@ __all__ = [
     "check_connection",
     "stream",
     "generate",
+    "get_model",
     "models",
     "providers",
     # Provider factories
@@ -94,6 +99,7 @@ __all__ = [
     "abort_pending_hook",
     # Submodules
     "events",
+    "errors",
     "messages",
     "mcp",
     "tools",

--- a/src/ai/_modelsdev.py
+++ b/src/ai/_modelsdev.py
@@ -10,24 +10,37 @@ if TYPE_CHECKING:
 
 _ENV_REFERENCE_RE = re.compile(r"\$\{?([A-Z_][A-Z0-9_]*)\}?")
 _SECRET_ENV_MARKERS = ("API_KEY", "TOKEN", "SECRET", "BEARER")
+_PROVIDER_ID_ALIASES = {"ai-gateway": "vercel"}
 
 
 def parse_model_id(model_id: str) -> modelsdotdev.ModelRef:
     import modelsdotdev
 
-    return modelsdotdev.parse_model_id(model_id)
+    return modelsdotdev.parse_model_id(_canonical_model_id(model_id))
 
 
 def get_provider_by_id(provider_id: str) -> modelsdotdev.Provider | None:
     import modelsdotdev
 
-    return modelsdotdev.get_provider_by_id(provider_id)
+    return modelsdotdev.get_provider_by_id(_canonical_provider_id(provider_id))
 
 
 def get_model_by_id(model_id: str) -> modelsdotdev.Model | None:
     import modelsdotdev
 
-    return modelsdotdev.get_model_by_id(model_id)
+    return modelsdotdev.get_model_by_id(_canonical_model_id(model_id))
+
+
+def _canonical_provider_id(provider_id: str) -> str:
+    return _PROVIDER_ID_ALIASES.get(provider_id, provider_id)
+
+
+def _canonical_model_id(model_id: str) -> str:
+    for separator in (":", "/"):
+        prefix, sep, rest = model_id.partition(separator)
+        if sep and prefix in _PROVIDER_ID_ALIASES:
+            return f"{_PROVIDER_ID_ALIASES[prefix]}{separator}{rest}"
+    return model_id
 
 
 def provider_base_url(

--- a/src/ai/_modelsdev.py
+++ b/src/ai/_modelsdev.py
@@ -3,10 +3,8 @@
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
-    import modelsdotdev
+import modelsdotdev
 
 _ENV_REFERENCE_RE = re.compile(r"\$\{?([A-Z_][A-Z0-9_]*)\}?")
 _SECRET_ENV_MARKERS = ("API_KEY", "TOKEN", "SECRET", "BEARER")
@@ -14,20 +12,14 @@ _PROVIDER_ID_ALIASES = {"ai-gateway": "vercel", "gateway": "vercel"}
 
 
 def parse_model_id(model_id: str) -> modelsdotdev.ModelRef:
-    import modelsdotdev
-
     return modelsdotdev.parse_model_id(_canonical_model_id(model_id))
 
 
 def get_provider_by_id(provider_id: str) -> modelsdotdev.Provider | None:
-    import modelsdotdev
-
     return modelsdotdev.get_provider_by_id(_canonical_provider_id(provider_id))
 
 
 def get_model_by_id(model_id: str) -> modelsdotdev.Model | None:
-    import modelsdotdev
-
     return modelsdotdev.get_model_by_id(_canonical_model_id(model_id))
 
 

--- a/src/ai/_modelsdev.py
+++ b/src/ai/_modelsdev.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
 
 _ENV_REFERENCE_RE = re.compile(r"\$\{?([A-Z_][A-Z0-9_]*)\}?")
 _SECRET_ENV_MARKERS = ("API_KEY", "TOKEN", "SECRET", "BEARER")
-_PROVIDER_ID_ALIASES = {"ai-gateway": "vercel"}
+_PROVIDER_ID_ALIASES = {"ai-gateway": "vercel", "gateway": "vercel"}
 
 
 def parse_model_id(model_id: str) -> modelsdotdev.ModelRef:

--- a/src/ai/_modelsdev.py
+++ b/src/ai/_modelsdev.py
@@ -1,0 +1,84 @@
+"""Helpers for models.dev metadata."""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import modelsdotdev
+
+_ENV_REFERENCE_RE = re.compile(r"\$\{?([A-Z_][A-Z0-9_]*)\}?")
+_SECRET_ENV_MARKERS = ("API_KEY", "TOKEN", "SECRET", "BEARER")
+
+
+def parse_model_id(model_id: str) -> modelsdotdev.ModelRef:
+    import modelsdotdev
+
+    return modelsdotdev.parse_model_id(model_id)
+
+
+def get_provider_by_id(provider_id: str) -> modelsdotdev.Provider | None:
+    import modelsdotdev
+
+    return modelsdotdev.get_provider_by_id(provider_id)
+
+
+def get_model_by_id(model_id: str) -> modelsdotdev.Model | None:
+    import modelsdotdev
+
+    return modelsdotdev.get_model_by_id(model_id)
+
+
+def provider_base_url(
+    provider: modelsdotdev.Provider,
+    model_provider_config: modelsdotdev.ModelProviderConfig | None = None,
+) -> str | None:
+    if model_provider_config is not None and model_provider_config.api is not None:
+        return model_provider_config.api
+    return provider.api
+
+
+def provider_config(
+    provider: modelsdotdev.Provider,
+    model_provider_config: modelsdotdev.ModelProviderConfig | None = None,
+) -> tuple[str | None, tuple[str, ...]]:
+    """Return ``api_key_env`` and non-secret config envs from models.dev data."""
+    api = provider_base_url(provider, model_provider_config)
+    envs = _provider_envs(provider, api)
+    api_key_env = _api_key_env(envs, api)
+    config_envs = tuple(env for env in envs if env != api_key_env)
+    return api_key_env, config_envs
+
+
+def provider_npm(
+    provider: modelsdotdev.Provider,
+    model_provider_config: modelsdotdev.ModelProviderConfig | None = None,
+) -> str:
+    if model_provider_config is not None and model_provider_config.npm is not None:
+        return model_provider_config.npm
+    return provider.npm
+
+
+def _provider_envs(provider: modelsdotdev.Provider, api: str | None) -> tuple[str, ...]:
+    envs = list(provider.env)
+    for env in _ENV_REFERENCE_RE.findall(api or ""):
+        if env not in envs:
+            envs.append(env)
+    return tuple(envs)
+
+
+def _api_key_env(envs: tuple[str, ...], api: str | None) -> str | None:
+    if not envs:
+        return None
+
+    referenced_envs = set(_ENV_REFERENCE_RE.findall(api or ""))
+    candidates = [env for env in envs if env not in referenced_envs]
+    if not candidates:
+        candidates = list(envs)
+
+    for marker in _SECRET_ENV_MARKERS:
+        for env in candidates:
+            if marker in env:
+                return env
+    return candidates[0]

--- a/src/ai/errors.py
+++ b/src/ai/errors.py
@@ -7,6 +7,10 @@ class AIError(Exception):
     """Base class for framework errors."""
 
 
+class ConfigurationError(AIError):
+    """Required SDK configuration is missing or invalid."""
+
+
 class UnsupportedProviderError(AIError):
     """The SDK does not support or recognize this provider yet."""
 
@@ -15,4 +19,4 @@ class UnsupportedProviderError(AIError):
         super().__init__(f"unsupported provider {provider_id!r}")
 
 
-__all__ = ["AIError", "UnsupportedProviderError"]
+__all__ = ["AIError", "ConfigurationError", "UnsupportedProviderError"]

--- a/src/ai/errors.py
+++ b/src/ai/errors.py
@@ -1,0 +1,18 @@
+"""Framework error hierarchy."""
+
+from __future__ import annotations
+
+
+class AIError(Exception):
+    """Base class for framework errors."""
+
+
+class UnsupportedProviderError(AIError):
+    """The SDK does not support or recognize this provider yet."""
+
+    def __init__(self, provider_id: str) -> None:
+        self.provider_id = provider_id
+        super().__init__(f"unsupported provider {provider_id!r}")
+
+
+__all__ = ["AIError", "UnsupportedProviderError"]

--- a/src/ai/models/__init__.py
+++ b/src/ai/models/__init__.py
@@ -44,7 +44,7 @@ from .core.api import (
     stream,
 )
 from .core.client import Client
-from .core.model import Model
+from .core.model import Model, get_model
 from .core.params import GenerateParams, ImageParams, VideoParams
 from .core.proto import CheckConnFn, GenerateFn, StreamFn
 
@@ -71,5 +71,6 @@ __all__ = [
     # Public API
     "check_connection",
     "generate",
+    "get_model",
     "stream",
 ]

--- a/src/ai/models/__init__.py
+++ b/src/ai/models/__init__.py
@@ -3,15 +3,15 @@
 Usage::
 
     import ai
-    from ai.providers import openai, openai_like, anthropic, anthropic_like, ai_gateway
+    from ai.providers import openai_like, anthropic_like
 
-    model = openai("gpt-5.4")
+    model = ai.get_model("openai:gpt-5.4")
     model = openai_like(name="local", base_url="http://localhost:11434/v1")("llama3")
-    model = anthropic("claude-sonnet-4-6")
+    model = ai.get_model("anthropic:claude-sonnet-4-6")
     model = anthropic_like(name="custom", base_url="https://anthropic.example.com")(
         "claude-sonnet-4-6"
     )
-    model = ai_gateway("anthropic/claude-sonnet-4")
+    model = ai.get_model("anthropic/claude-sonnet-4")  # defaults to Gateway
 
     # stream — auto-creates client from env vars
     msgs = [ai.user_message("hello")]
@@ -22,7 +22,7 @@ Usage::
 
     # explicit client for custom auth
     client = ai.Client(base_url="https://custom.example.com/v1", api_key="sk-...")
-    model = openai("gpt-5.4", client=client)
+    model = ai.get_model("openai:gpt-5.4", client=client)
     async with ai.stream(model, msgs) as s:
         ...
 

--- a/src/ai/models/core/__init__.py
+++ b/src/ai/models/core/__init__.py
@@ -15,7 +15,7 @@ from .api import (
     stream,
 )
 from .client import Client
-from .model import Model
+from .model import Model, get_model
 from .params import GenerateParams, ImageParams, VideoParams
 from .proto import CheckConnFn, GenerateFn, StreamFn
 
@@ -37,6 +37,7 @@ __all__ = [
     "VideoParams",
     "check_connection",
     "generate",
+    "get_model",
     "register_generate",
     "register_stream",
     "stream",

--- a/src/ai/models/core/model.py
+++ b/src/ai/models/core/model.py
@@ -42,8 +42,8 @@ def get_model(model_id: str | None = None, *, client: Client | None = None) -> M
             from its default base URL and environment variables.
 
     Raises:
-        Raises :class:`ai.ConfigurationError` when ``model_id`` is omitted and
-        ``AI_SDK_DEFAULT_MODEL`` is not set.
+        Raises :class:`ai.ConfigurationError` when ``model_id`` and
+        ``AI_SDK_DEFAULT_MODEL`` is empty or malformed.
         Raises a :class:`ai.UnsupportedProviderError` when the provider is
         unrecognized or otherwise unsupported.
     """
@@ -51,9 +51,12 @@ def get_model(model_id: str | None = None, *, client: Client | None = None) -> M
         model_id = os.environ.get(_DEFAULT_MODEL_ENV)
         if not model_id:
             raise ConfigurationError(
-                f"{_DEFAULT_MODEL_ENV} must be set to call get_model() "
-                "without arguments"
+                f"{_DEFAULT_MODEL_ENV} must be set when ai.get_model() "
+                "is called without arguments"
             )
+
+    if not model_id:
+        raise ConfigurationError(f"get_model: malformed model_id: {model_id!r}")
 
     if ":" not in model_id:
         model_id = f"gateway:{model_id}"
@@ -66,7 +69,9 @@ def get_model(model_id: str | None = None, *, client: Client | None = None) -> M
     model_info = _modelsdev.get_model_by_id(f"{provider_id}:{provider_model_id}")
     model_provider_config = None if model_info is None else model_info.provider_config
 
-    return base.Provider.from_id(
+    provider = base.Provider.from_id(
         provider_id,
         model_provider_config=model_provider_config,
-    )(provider_model_id, client=client)
+    )
+
+    return provider(provider_model_id, client=client)

--- a/src/ai/models/core/model.py
+++ b/src/ai/models/core/model.py
@@ -55,20 +55,17 @@ def get_model(model_id: str | None = None, *, client: Client | None = None) -> M
                 "without arguments"
             )
 
-    if not model_id:
-        raise ValueError("model_id must not be empty")
-    if ":" in model_id:
-        ref = _modelsdev.parse_model_id(model_id)
-        if ref.provider_id is None:
-            raise ValueError("model_id must include a known provider id")
-        provider_id = ref.provider_id
-        provider_model_id = ref.model_id
-    else:
-        provider_id = "gateway"
-        provider_model_id = model_id
+    if ":" not in model_id:
+        model_id = f"gateway:{model_id}"
+
+    ref = _modelsdev.parse_model_id(model_id)
+    assert ref.provider_id is not None  # guaranteed to be fully-qualified here
+    provider_id = ref.provider_id
+    provider_model_id = ref.model_id
 
     model_info = _modelsdev.get_model_by_id(f"{provider_id}:{provider_model_id}")
     model_provider_config = None if model_info is None else model_info.provider_config
+
     return base.Provider.from_id(
         provider_id,
         model_provider_config=model_provider_config,

--- a/src/ai/models/core/model.py
+++ b/src/ai/models/core/model.py
@@ -2,6 +2,7 @@
 
 import dataclasses
 
+from ... import _modelsdev
 from ...providers import base
 from .client import Client
 
@@ -20,3 +21,26 @@ class Model:
     adapter: str
     provider: base.Provider
     client: Client | None = dataclasses.field(default=None, repr=False)
+
+
+def get_model(model_id: str) -> Model:
+    """Resolve a provider-qualified model ID into a :class:`Model`.
+
+    Args:
+        model_id:
+            Model ID in the format of `provider:model`.
+            Example: ``"openai:gpt-5"``.
+
+    Raises:
+        Raises a :class:`ai.UnsupportedProviderError` when the provider is
+        unrecognized or otherwise unsupported.
+    """
+    ref = _modelsdev.parse_model_id(model_id)
+    if ref.provider_id is None:
+        raise ValueError("model_id must include a known provider id")
+    model_info = _modelsdev.get_model_by_id(f"{ref.provider_id}:{ref.model_id}")
+    model_provider_config = None if model_info is None else model_info.provider_config
+    return base.Provider.from_id(
+        ref.provider_id,
+        model_provider_config=model_provider_config,
+    )(ref.model_id)

--- a/src/ai/models/core/model.py
+++ b/src/ai/models/core/model.py
@@ -1,10 +1,14 @@
 """Model metadata types."""
 
 import dataclasses
+import os
 
 from ... import _modelsdev
+from ...errors import ConfigurationError
 from ...providers import base
 from .client import Client
+
+_DEFAULT_MODEL_ENV = "AI_SDK_DEFAULT_MODEL"
 
 
 @dataclasses.dataclass(frozen=True)
@@ -23,24 +27,49 @@ class Model:
     client: Client | None = dataclasses.field(default=None, repr=False)
 
 
-def get_model(model_id: str) -> Model:
-    """Resolve a provider-qualified model ID into a :class:`Model`.
+def get_model(model_id: str | None = None, *, client: Client | None = None) -> Model:
+    """Resolve a model ID into a :class:`Model`.
 
     Args:
         model_id:
-            Model ID in the format of `provider:model`.
-            Example: ``"openai:gpt-5"``.
+            Model ID, optionally in the format of ``"provider:model"``.
+            When the provider is omitted, the model is routed through the
+            gateway. Examples: ``"openai:gpt-5"`` or
+            ``"anthropic/claude-sonnet-4"``. When omitted, reads
+            ``AI_SDK_DEFAULT_MODEL`` from the environment.
+        client:
+            Explicit client override. When omitted, the provider creates one
+            from its default base URL and environment variables.
 
     Raises:
+        Raises :class:`ai.ConfigurationError` when ``model_id`` is omitted and
+        ``AI_SDK_DEFAULT_MODEL`` is not set.
         Raises a :class:`ai.UnsupportedProviderError` when the provider is
         unrecognized or otherwise unsupported.
     """
-    ref = _modelsdev.parse_model_id(model_id)
-    if ref.provider_id is None:
-        raise ValueError("model_id must include a known provider id")
-    model_info = _modelsdev.get_model_by_id(f"{ref.provider_id}:{ref.model_id}")
+    if model_id is None:
+        model_id = os.environ.get(_DEFAULT_MODEL_ENV)
+        if not model_id:
+            raise ConfigurationError(
+                f"{_DEFAULT_MODEL_ENV} must be set to call get_model() "
+                "without arguments"
+            )
+
+    if not model_id:
+        raise ValueError("model_id must not be empty")
+    if ":" in model_id:
+        ref = _modelsdev.parse_model_id(model_id)
+        if ref.provider_id is None:
+            raise ValueError("model_id must include a known provider id")
+        provider_id = ref.provider_id
+        provider_model_id = ref.model_id
+    else:
+        provider_id = "gateway"
+        provider_model_id = model_id
+
+    model_info = _modelsdev.get_model_by_id(f"{provider_id}:{provider_model_id}")
     model_provider_config = None if model_info is None else model_info.provider_config
     return base.Provider.from_id(
-        ref.provider_id,
+        provider_id,
         model_provider_config=model_provider_config,
-    )(ref.model_id)
+    )(provider_model_id, client=client)

--- a/src/ai/models/core/model.py
+++ b/src/ai/models/core/model.py
@@ -33,8 +33,8 @@ def get_model(model_id: str | None = None, *, client: Client | None = None) -> M
     Args:
         model_id:
             Model ID, optionally in the format of ``"provider:model"``.
-            When the provider is omitted, the model is routed through the
-            gateway. Examples: ``"openai:gpt-5"`` or
+            When the provider is omitted, the model is routed through
+            Vercel AI Gateway. Examples: ``"openai:gpt-5"`` or
             ``"anthropic/claude-sonnet-4"``. When omitted, reads
             ``AI_SDK_DEFAULT_MODEL`` from the environment.
         client:

--- a/src/ai/providers/ai_gateway/provider.py
+++ b/src/ai/providers/ai_gateway/provider.py
@@ -2,11 +2,16 @@
 
 Defines the callable :data:`ai_gateway` provider."""
 
+from __future__ import annotations
+
 from types import ModuleType
-from typing import Any
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from ...models import core
 from .. import base
+
+if TYPE_CHECKING:
+    import modelsdotdev
 
 _BASE_URL = "https://ai-gateway.vercel.sh/v3/ai"
 _API_KEY_ENV = "AI_GATEWAY_API_KEY"
@@ -15,6 +20,8 @@ _API_KEY_ENV = "AI_GATEWAY_API_KEY"
 class _AIGateway(base.Provider):
     """Callable provider factory for the Vercel AI Gateway."""
 
+    handles: ClassVar[tuple[str, ...]] = ("vercel", "@ai-sdk/gateway")
+
     def __init__(self) -> None:
         super().__init__(
             name="ai-gateway",
@@ -22,6 +29,15 @@ class _AIGateway(base.Provider):
             base_url=_BASE_URL,
             api_key_env=_API_KEY_ENV,
         )
+
+    @classmethod
+    def from_modelsdev_provider(
+        cls,
+        provider: modelsdotdev.Provider,
+        *,
+        model_provider_config: modelsdotdev.ModelProviderConfig | None = None,
+    ) -> base.Provider:
+        return ai_gateway
 
     @property
     def tools(self) -> ModuleType:

--- a/src/ai/providers/anthropic/provider.py
+++ b/src/ai/providers/anthropic/provider.py
@@ -1,10 +1,16 @@
 """Anthropic-compatible providers."""
 
+from __future__ import annotations
+
 from collections.abc import Iterable
 from types import ModuleType
+from typing import TYPE_CHECKING, ClassVar
 
 from ...models import core
 from .. import base
+
+if TYPE_CHECKING:
+    import modelsdotdev
 
 _BASE_URL = "https://api.anthropic.com"
 _BASE_URL_ENV = "ANTHROPIC_BASE_URL"
@@ -14,6 +20,8 @@ _ANTHROPIC_VERSION = "2023-06-01"
 
 class AnthropicCompatibleProvider(base.Provider):
     """Callable provider for Anthropic-compatible APIs."""
+
+    handles: ClassVar[tuple[str, ...]] = ("anthropic", "@ai-sdk/anthropic")
 
     def __init__(
         self,
@@ -34,6 +42,26 @@ class AnthropicCompatibleProvider(base.Provider):
             config_envs=config_envs,
         )
         self.anthropic_version = anthropic_version
+
+    @classmethod
+    def from_modelsdev_provider(
+        cls,
+        provider: modelsdotdev.Provider,
+        *,
+        model_provider_config: modelsdotdev.ModelProviderConfig | None = None,
+    ) -> base.Provider:
+        if provider.id == "anthropic" and model_provider_config is None:
+            return anthropic
+        base_url = base.provider_base_url(provider, model_provider_config)
+        if base_url is None:
+            raise ValueError(f"provider {provider.id!r} does not declare an API URL")
+        api_key_env, config_envs = base.provider_config(provider, model_provider_config)
+        return cls(
+            name=provider.id,
+            default_base_url=base_url,
+            api_key_env=api_key_env,
+            config_envs=config_envs,
+        )
 
     @property
     def tools(self) -> ModuleType:

--- a/src/ai/providers/base.py
+++ b/src/ai/providers/base.py
@@ -4,9 +4,14 @@ from __future__ import annotations
 
 import os
 from collections.abc import Iterable
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, ClassVar
+
+from .. import _modelsdev
+from ..errors import UnsupportedProviderError
 
 if TYPE_CHECKING:
+    import modelsdotdev
+
     from ..models.core.client import Client
     from ..models.core.model import Model
 
@@ -22,6 +27,16 @@ class Provider:
     Implementations must be **callable** — ``provider(model_id)`` returns
     a :class:`Model`.
     """
+
+    handles: ClassVar[tuple[str, ...]] = ()
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        super().__init_subclass__(**kwargs)
+        for handle in cls.handles:
+            existing = _PROVIDER_REGISTRY.get(handle)
+            if existing is not None and existing is not cls:
+                raise RuntimeError(f"duplicate provider handle: {handle!r}")
+            _PROVIDER_REGISTRY[handle] = cls
 
     def __init__(
         self,
@@ -127,3 +142,57 @@ class Provider:
 
     def __repr__(self) -> str:
         return self.name
+
+    @classmethod
+    def from_id(
+        cls,
+        known_id: str,
+        *,
+        model_provider_config: modelsdotdev.ModelProviderConfig | None = None,
+    ) -> Provider:
+        """Return a concrete provider for a models.dev provider ID."""
+        provider = _modelsdev.get_provider_by_id(known_id)
+        if provider is None:
+            raise ValueError(f"unknown provider id: {known_id!r}")
+
+        for handle in (
+            provider.id,
+            _modelsdev.provider_npm(provider, model_provider_config),
+        ):
+            provider_type = _PROVIDER_REGISTRY.get(handle)
+            if provider_type is not None:
+                return provider_type.from_modelsdev_provider(
+                    provider,
+                    model_provider_config=model_provider_config,
+                )
+
+        raise UnsupportedProviderError(provider.id)
+
+    @classmethod
+    def from_modelsdev_provider(
+        cls,
+        provider: modelsdotdev.Provider,
+        *,
+        model_provider_config: modelsdotdev.ModelProviderConfig | None = None,
+    ) -> Provider:
+        """Construct this provider implementation from models.dev metadata."""
+        raise NotImplementedError
+
+
+_PROVIDER_REGISTRY: dict[str, type[Provider]] = {}
+
+
+def provider_config(
+    provider: modelsdotdev.Provider,
+    model_provider_config: modelsdotdev.ModelProviderConfig | None = None,
+) -> tuple[str | None, tuple[str, ...]]:
+    """Return ``api_key_env`` and non-secret config envs from models.dev data."""
+    return _modelsdev.provider_config(provider, model_provider_config)
+
+
+def provider_base_url(
+    provider: modelsdotdev.Provider,
+    model_provider_config: modelsdotdev.ModelProviderConfig | None = None,
+) -> str | None:
+    """Return model-specific API URL override or provider API URL."""
+    return _modelsdev.provider_base_url(provider, model_provider_config)

--- a/src/ai/providers/openai/provider.py
+++ b/src/ai/providers/openai/provider.py
@@ -1,10 +1,16 @@
 """OpenAI-compatible providers."""
 
+from __future__ import annotations
+
 from collections.abc import Iterable
 from types import ModuleType
+from typing import TYPE_CHECKING, ClassVar
 
 from ...models import core
 from .. import base
+
+if TYPE_CHECKING:
+    import modelsdotdev
 
 _BASE_URL = "https://api.openai.com/v1"
 _BASE_URL_ENV = "OPENAI_BASE_URL"
@@ -17,6 +23,12 @@ class OpenAICompatibleProvider(base.Provider):
     ``provider("gpt-5.4")`` returns a :class:`Model` that uses the OpenAI
     chat-completions adapter.
     """
+
+    handles: ClassVar[tuple[str, ...]] = (
+        "openai",
+        "@ai-sdk/openai",
+        "@ai-sdk/openai-compatible",
+    )
 
     def __init__(
         self,
@@ -33,6 +45,26 @@ class OpenAICompatibleProvider(base.Provider):
             base_url=default_base_url,
             api_key_env=api_key_env,
             base_url_env=base_url_env,
+            config_envs=config_envs,
+        )
+
+    @classmethod
+    def from_modelsdev_provider(
+        cls,
+        provider: modelsdotdev.Provider,
+        *,
+        model_provider_config: modelsdotdev.ModelProviderConfig | None = None,
+    ) -> base.Provider:
+        if provider.id == "openai" and model_provider_config is None:
+            return openai
+        base_url = base.provider_base_url(provider, model_provider_config)
+        if base_url is None:
+            raise ValueError(f"provider {provider.id!r} does not declare an API URL")
+        api_key_env, config_envs = base.provider_config(provider, model_provider_config)
+        return cls(
+            name=provider.id,
+            default_base_url=base_url,
+            api_key_env=api_key_env,
             config_envs=config_envs,
         )
 

--- a/tests/models/test_resolution.py
+++ b/tests/models/test_resolution.py
@@ -13,12 +13,50 @@ def test_get_resolves_provider_qualified_model_id() -> None:
     assert model.provider is openai
 
 
-def test_get_resolves_slash_qualified_model_id() -> None:
-    model = models.get_model("anthropic/claude-sonnet-4-5")
+def test_get_resolves_provider_qualified_anthropic_model_id() -> None:
+    model = models.get_model("anthropic:claude-sonnet-4-5")
 
     assert model.id == "claude-sonnet-4-5"
     assert model.adapter == "anthropic"
     assert model.provider is anthropic
+
+
+def test_get_defaults_to_gateway_when_provider_is_omitted() -> None:
+    model = models.get_model("anthropic/claude-sonnet-4")
+
+    assert model.id == "anthropic/claude-sonnet-4"
+    assert model.adapter == "ai-gateway-v3"
+    assert model.provider is ai_gateway
+
+
+def test_get_uses_default_model_env_when_model_id_is_omitted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AI_SDK_DEFAULT_MODEL", "anthropic/claude-sonnet-4")
+
+    model = models.get_model()
+
+    assert model.id == "anthropic/claude-sonnet-4"
+    assert model.adapter == "ai-gateway-v3"
+    assert model.provider is ai_gateway
+
+
+def test_get_rejects_missing_default_model_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("AI_SDK_DEFAULT_MODEL", raising=False)
+
+    with pytest.raises(ai.ConfigurationError, match="AI_SDK_DEFAULT_MODEL"):
+        models.get_model()
+
+
+def test_get_rejects_empty_default_model_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AI_SDK_DEFAULT_MODEL", "")
+
+    with pytest.raises(ai.ConfigurationError, match="AI_SDK_DEFAULT_MODEL"):
+        models.get_model()
 
 
 def test_provider_from_id_resolves_openai_compatible_provider() -> None:
@@ -57,6 +95,7 @@ def test_provider_from_id_resolves_gateway_provider() -> None:
 
 def test_provider_from_id_resolves_gateway_alias() -> None:
     assert models.Provider.from_id("ai-gateway") is ai_gateway
+    assert models.Provider.from_id("gateway") is ai_gateway
 
 
 def test_get_resolves_gateway_alias() -> None:
@@ -65,6 +104,9 @@ def test_get_resolves_gateway_alias() -> None:
     assert model.id == "alibaba/qwen-3-14b"
     assert model.adapter == "ai-gateway-v3"
     assert model.provider is ai_gateway
+
+    gateway_model = models.get_model("gateway:alibaba/qwen-3-14b")
+    assert gateway_model == model
 
 
 def test_get_uses_model_provider_config_for_anthropic_compatibility() -> None:
@@ -110,6 +152,6 @@ def test_get_rejects_unsupported_provider_package() -> None:
         models.get_model("google:gemini-2.5-pro")
 
 
-def test_get_rejects_unqualified_model_id() -> None:
-    with pytest.raises(ValueError, match="known provider id"):
-        models.get_model("gpt-5")
+def test_get_rejects_empty_model_id() -> None:
+    with pytest.raises(ValueError, match="must not be empty"):
+        models.get_model("")

--- a/tests/models/test_resolution.py
+++ b/tests/models/test_resolution.py
@@ -55,6 +55,18 @@ def test_provider_from_id_resolves_gateway_provider() -> None:
     assert models.Provider.from_id("vercel") is ai_gateway
 
 
+def test_provider_from_id_resolves_gateway_alias() -> None:
+    assert models.Provider.from_id("ai-gateway") is ai_gateway
+
+
+def test_get_resolves_gateway_alias() -> None:
+    model = models.get_model("ai-gateway:alibaba/qwen-3-14b")
+
+    assert model.id == "alibaba/qwen-3-14b"
+    assert model.adapter == "ai-gateway-v3"
+    assert model.provider is ai_gateway
+
+
 def test_get_uses_model_provider_config_for_anthropic_compatibility() -> None:
     model = models.get_model("azure:claude-sonnet-4-5")
 

--- a/tests/models/test_resolution.py
+++ b/tests/models/test_resolution.py
@@ -1,7 +1,7 @@
 import pytest
 
 import ai
-from ai import models
+from ai import ConfigurationError, models
 from ai.providers import ai_gateway, anthropic, openai
 
 
@@ -153,5 +153,5 @@ def test_get_rejects_unsupported_provider_package() -> None:
 
 
 def test_get_rejects_empty_model_id() -> None:
-    with pytest.raises(ValueError, match="must not be empty"):
+    with pytest.raises(ConfigurationError, match="malformed model_id: ''"):
         models.get_model("")

--- a/tests/models/test_resolution.py
+++ b/tests/models/test_resolution.py
@@ -1,0 +1,103 @@
+import pytest
+
+import ai
+from ai import models
+from ai.providers import ai_gateway, anthropic, openai
+
+
+def test_get_resolves_provider_qualified_model_id() -> None:
+    model = ai.get_model("openai:gpt-5")
+
+    assert model.id == "gpt-5"
+    assert model.adapter == "openai"
+    assert model.provider is openai
+
+
+def test_get_resolves_slash_qualified_model_id() -> None:
+    model = models.get_model("anthropic/claude-sonnet-4-5")
+
+    assert model.id == "claude-sonnet-4-5"
+    assert model.adapter == "anthropic"
+    assert model.provider is anthropic
+
+
+def test_provider_from_id_resolves_openai_compatible_provider() -> None:
+    provider = models.Provider.from_id("deepseek")
+
+    assert provider.name == "deepseek"
+    assert provider.adapter == "openai"
+    assert provider.default_base_url == "https://api.deepseek.com"
+    assert provider.api_key_env == "DEEPSEEK_API_KEY"
+    assert provider.config_envs == ()
+
+
+def test_provider_from_id_uses_template_envs_for_base_url() -> None:
+    provider = models.Provider.from_id("cloudflare-workers-ai")
+
+    assert provider.default_base_url == (
+        "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/ai/v1"
+    )
+    assert provider.api_key_env == "CLOUDFLARE_API_KEY"
+    assert provider.config_envs == ("CLOUDFLARE_ACCOUNT_ID",)
+
+
+def test_provider_from_id_detects_token_env_after_url_env() -> None:
+    provider = models.Provider.from_id("databricks")
+
+    assert (
+        provider.default_base_url == "https://${DATABRICKS_HOST}/ai-gateway/mlflow/v1"
+    )
+    assert provider.api_key_env == "DATABRICKS_TOKEN"
+    assert provider.config_envs == ("DATABRICKS_HOST",)
+
+
+def test_provider_from_id_resolves_gateway_provider() -> None:
+    assert models.Provider.from_id("vercel") is ai_gateway
+
+
+def test_get_uses_model_provider_config_for_anthropic_compatibility() -> None:
+    model = models.get_model("azure:claude-sonnet-4-5")
+
+    assert model.id == "claude-sonnet-4-5"
+    assert model.adapter == "anthropic"
+    assert model.provider.name == "azure"
+    assert model.provider.default_base_url == (
+        "https://${AZURE_RESOURCE_NAME}.services.ai.azure.com/anthropic/v1"
+    )
+    assert model.provider.api_key_env == "AZURE_API_KEY"
+    assert model.provider.config_envs == ("AZURE_RESOURCE_NAME",)
+
+
+def test_get_uses_model_provider_config_for_openai_compatibility() -> None:
+    model = models.get_model("azure:kimi-k2.5")
+
+    assert model.id == "kimi-k2.5"
+    assert model.adapter == "openai"
+    assert model.provider.name == "azure"
+    assert model.provider.default_base_url == (
+        "https://${AZURE_RESOURCE_NAME}.services.ai.azure.com/models"
+    )
+    assert model.provider.api_key_env == "AZURE_API_KEY"
+    assert model.provider.config_envs == ("AZURE_RESOURCE_NAME",)
+
+
+def test_provider_from_id_rejects_unknown_provider() -> None:
+    with pytest.raises(ValueError, match="unknown provider id"):
+        models.Provider.from_id("missing-provider")
+
+
+def test_provider_from_id_rejects_unsupported_provider_package() -> None:
+    with pytest.raises(ai.UnsupportedProviderError) as exc_info:
+        models.Provider.from_id("google")
+
+    assert exc_info.value.provider_id == "google"
+
+
+def test_get_rejects_unsupported_provider_package() -> None:
+    with pytest.raises(ai.errors.UnsupportedProviderError):
+        models.get_model("google:gemini-2.5-pro")
+
+
+def test_get_rejects_unqualified_model_id() -> None:
+    with pytest.raises(ValueError, match="known provider id"):
+        models.get_model("gpt-5")

--- a/uv.lock
+++ b/uv.lock
@@ -492,6 +492,11 @@ wheels = [
 ]
 
 [[package]]
+name = "modelsdotdev"
+version = "0.0.0"
+source = { git = "https://github.com/vercel-labs/modelsdotdev-python#8e57c6a97b05fcc72866bf36081b7bbf80c34bb0" }
+
+[[package]]
 name = "mypy"
 version = "1.19.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1034,6 +1039,7 @@ dependencies = [
     { name = "anthropic" },
     { name = "httpx" },
     { name = "mcp" },
+    { name = "modelsdotdev" },
     { name = "openai" },
     { name = "pydantic" },
     { name = "typing-extensions" },
@@ -1057,6 +1063,7 @@ requires-dist = [
     { name = "anthropic", specifier = ">=0.83.0" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "mcp", specifier = ">=1.18.0" },
+    { name = "modelsdotdev", git = "https://github.com/vercel-labs/modelsdotdev-python" },
     { name = "openai", specifier = ">=2.14.0" },
     { name = "pydantic", specifier = ">=2.12.5" },
     { name = "typing-extensions", specifier = ">=4.15.0" },


### PR DESCRIPTION
Use the models.dev database (via `modelsdotdev`) to fully resolve and
configure a provider/model pair.  Providers can now declare
compatibility aliases which match either the canonical provider id in
the database or JS AI SDK package name (also from the database), so this
makes this SDK automatically support all models.dev providers annotated
with `@ai-sdk/anthropic` or `@ai-sdk/openai-compatible`.  Use database
information to automatically configure env secrets and API URLs as well
as per-model headers where applicable.
