### PR TITLE
Fix project metadata, add LICENSE, switch to vcs-derived version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,7 +137,7 @@ celerybeat.pid
 # Environments
 .env
 .envrc
-.venv
+.venv*
 env/
 venv/
 ENV/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,13 @@
+Copyright 2026 Vercel, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/examples/fastapi-vite/README.md
+++ b/examples/fastapi-vite/README.md
@@ -6,7 +6,7 @@ behind user confirmation before execution.
 
 ## Stack
 
-- **Backend:** FastAPI + vercel-ai-sdk (Python 3.12)
+- **Backend:** FastAPI + AI SDK for Python (Python 3.12)
 - **Frontend:** Vite + React + AI SDK UI + AI Elements
 
 ## Human-in-the-Loop
@@ -55,8 +55,8 @@ The frontend dev server proxies `/api` requests to the backend at `localhost:800
 
 ## Environment Variables
 
-| Variable | Description |
-|----------|-------------|
+| Variable             | Description               |
+| -------------------- | ------------------------- |
 | `AI_GATEWAY_API_KEY` | Vercel AI Gateway API key |
 
 ## Storage

--- a/examples/fastapi-vite/backend/pyproject.toml
+++ b/examples/fastapi-vite/backend/pyproject.toml
@@ -5,5 +5,5 @@ description = "Chat demo using Python Vercel AI SDK with FastAPI"
 requires-python = ">=3.12"
 dependencies = [
     "fastapi[standard]>=0.128.1",
-    "vercel-ai-sdk>=0.0.1.dev5",
+    "ai>=0.0.1.dev5",
 ]

--- a/examples/fastapi-vite/backend/uv.lock
+++ b/examples/fastapi-vite/backend/uv.lock
@@ -701,13 +701,13 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "fastapi", extra = ["standard"] },
-    { name = "vercel-ai-sdk" },
+    { name = "ai" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "fastapi", extras = ["standard"], specifier = ">=0.128.1" },
-    { name = "vercel-ai-sdk", specifier = ">=0.0.1.dev5" },
+    { name = "ai", specifier = ">=0.0.1.dev5" },
 ]
 
 [[package]]
@@ -1317,7 +1317,7 @@ wheels = [
 ]
 
 [[package]]
-name = "vercel-ai-sdk"
+name = "ai"
 version = "0.0.1.dev5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [

--- a/examples/fastapi-vite/frontend/src/App.tsx
+++ b/examples/fastapi-vite/frontend/src/App.tsx
@@ -61,9 +61,9 @@ export default function App() {
       <div className="flex h-screen flex-col bg-background">
         <header className="border-b px-4 py-3">
           <div className="mx-auto w-full max-w-3xl">
-            <h1 className="text-lg font-semibold">Python AI SDK Chat Demo</h1>
+            <h1 className="text-lg font-semibold">AI SDK Python Chat Demo</h1>
             <p className="text-sm text-muted-foreground">
-              Powered by vercel-ai-sdk + FastAPI
+              Powered by AI SDK for Python and FastAPI
             </p>
           </div>
         </header>

--- a/examples/multiagent-textual/pyproject.toml
+++ b/examples/multiagent-textual/pyproject.toml
@@ -5,10 +5,10 @@ description = "Multi-agent hook resolution demo with Textual TUI"
 requires-python = ">=3.12"
 dependencies = [
     "fastapi[standard]>=0.128.1",
-    "vercel-ai-sdk",
+    "ai",
     "textual>=3.0",
     "websockets>=15.0",
 ]
 
 [tool.uv.sources]
-vercel-ai-sdk = { path = "../..", editable = true }
+ai = { path = "../..", editable = true }

--- a/examples/multiagent-textual/uv.lock
+++ b/examples/multiagent-textual/uv.lock
@@ -712,7 +712,7 @@ source = { virtual = "." }
 dependencies = [
     { name = "fastapi", extra = ["standard"] },
     { name = "textual" },
-    { name = "vercel-ai-sdk" },
+    { name = "ai" },
     { name = "websockets" },
 ]
 
@@ -720,7 +720,7 @@ dependencies = [
 requires-dist = [
     { name = "fastapi", extras = ["standard"], specifier = ">=0.128.1" },
     { name = "textual", specifier = ">=3.0" },
-    { name = "vercel-ai-sdk", editable = "../../" },
+    { name = "ai", editable = "../../" },
     { name = "websockets", specifier = ">=15.0" },
 ]
 
@@ -1385,7 +1385,7 @@ wheels = [
 ]
 
 [[package]]
-name = "vercel-ai-sdk"
+name = "ai"
 version = "0.0.1.dev10"
 source = { editable = "../../" }
 dependencies = [

--- a/examples/temporal-direct/pyproject.toml
+++ b/examples/temporal-direct/pyproject.toml
@@ -4,9 +4,9 @@ version = "0.1.0"
 description = "Durable agent with a custom loop — every I/O call is a Temporal activity"
 requires-python = ">=3.12"
 dependencies = [
-    "vercel-ai-sdk",
+    "ai",
     "temporalio>=1.9.0",
 ]
 
 [tool.uv.sources]
-vercel-ai-sdk = { path = "../..", editable = true }
+ai = { path = "../..", editable = true }

--- a/examples/temporal-direct/uv.lock
+++ b/examples/temporal-direct/uv.lock
@@ -758,13 +758,13 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "temporalio" },
-    { name = "vercel-ai-sdk" },
+    { name = "ai" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "temporalio", specifier = ">=1.9.0" },
-    { name = "vercel-ai-sdk", editable = "../../" },
+    { name = "ai", editable = "../../" },
 ]
 
 [[package]]
@@ -860,7 +860,7 @@ wheels = [
 ]
 
 [[package]]
-name = "vercel-ai-sdk"
+name = "ai"
 version = "0.0.1.dev10"
 source = { editable = "../../" }
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,30 @@
 [project]
-name = "vercel-ai-sdk"
-version = "0.0.1.dev10"
-description = "The AI Toolkit for Python"
+name = "ai"
+dynamic = ["version"]
+description = "AI Agent Framework for Python"
+license = "Apache-2.0"
+license-files = ["LICENSE"]
 readme = "README.md"
 authors = [
     { name = "Andrey Buzin", email = "andrey.buzin@vercel.com" }
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Information Technology",
+    "License :: OSI Approved :: Apache Software License",
+    "Operating System :: OS Independent",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python",
+    "Topic :: Internet",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Typing :: Typed",
 ]
 requires-python = ">=3.12"
 dependencies = [
@@ -19,11 +39,19 @@ dependencies = [
 ]
 
 [build-system]
-requires = ["uv_build>=0.9.21,<0.12.0"]
-build-backend = "uv_build"
+requires = ["hatchling", "uv-dynamic-versioning>=0.7.0"]
+build-backend = "hatchling.build"
 
-[tool.uv.build-backend]
-module-name = "ai"
+[tool.hatch.metadata]
+allow-direct-references = true
+
+[tool.hatch.version]
+source = "uv-dynamic-versioning"
+
+[tool.uv-dynamic-versioning]
+vcs = "git"
+style = "pep440"
+bump = true
 
 [dependency-groups]
 dev = [
@@ -38,12 +66,12 @@ dev = [
 ]
 
 [tool.mypy]
-python_version = "3.13"
+python_version = "3.12"
 strict = true
 plugins = ["pydantic.mypy"]
 
 [tool.pyright]
-pythonVersion = "3.13"
+pythonVersion = "3.12"
 typeCheckingMode = "standard"
 reportMissingTypeStubs = false
 reportUnusedCallResult = false
@@ -53,7 +81,7 @@ asyncio_mode = "auto"
 testpaths = ["tests"]
 
 [tool.ruff]
-target-version = "py313"
+target-version = "py312"
 src = ["src"]
 
 [tool.ruff.lint]

--- a/skills/ai/SKILL.md
+++ b/skills/ai/SKILL.md
@@ -6,7 +6,7 @@ description: Python `ai` module — models, agents, hooks, MCP, structured outpu
 # ai
 
 ```bash
-uv add vercel-ai-sdk
+uv add ai
 ```
 
 ```python
@@ -66,7 +66,7 @@ Serialize: `msg.model_dump()`. Restore: `ai.messages.Message.model_validate(data
 
 ## Streaming tools
 
-A regular `@ai.tool` returns the tool result directly. An async-generator tool yields intermediate values that stream to the consumer as `ai.events.PartialToolCallResult` events; an *aggregator* decides what the model sees as the final result.
+A regular `@ai.tool` returns the tool result directly. An async-generator tool yields intermediate values that stream to the consumer as `ai.events.PartialToolCallResult` events; an _aggregator_ decides what the model sees as the final result.
 
 Declare the aggregator via the return-type annotation:
 

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,56 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "ai"
+source = { editable = "." }
+dependencies = [
+    { name = "anthropic" },
+    { name = "httpx" },
+    { name = "mcp" },
+    { name = "modelsdotdev" },
+    { name = "openai" },
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+    { name = "vercel" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "async-solipsism" },
+    { name = "mypy" },
+    { name = "pyright" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "python-dotenv" },
+    { name = "rich" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "anthropic", specifier = ">=0.83.0" },
+    { name = "httpx", specifier = ">=0.28.1" },
+    { name = "mcp", specifier = ">=1.18.0" },
+    { name = "modelsdotdev", git = "https://github.com/vercel-labs/modelsdotdev-python" },
+    { name = "openai", specifier = ">=2.14.0" },
+    { name = "pydantic", specifier = ">=2.12.5" },
+    { name = "typing-extensions", specifier = ">=4.15.0" },
+    { name = "vercel", specifier = ">=0.3.8" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "async-solipsism", specifier = ">=0.9" },
+    { name = "mypy", specifier = ">=1.11" },
+    { name = "pyright", specifier = ">=1.1.408" },
+    { name = "pytest", specifier = ">=8.0" },
+    { name = "pytest-asyncio", specifier = ">=0.24" },
+    { name = "python-dotenv", specifier = ">=1.2.1" },
+    { name = "rich", specifier = ">=14.2.0" },
+    { name = "ruff", specifier = ">=0.8" },
+]
+
+[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1029,57 +1079,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b9/ff/b44f61587e75cd8b78cc56324fe43ca6dbf104c94dcc9396579fdf2e0d69/vercel-0.3.8.tar.gz", hash = "sha256:047fdc66db775bb334c4a12aba3ac4f39bd56613e0216c7e05f1d57d7989d21d", size = 41814, upload-time = "2026-01-20T21:33:28.921Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/27/0d/acf76808ecc6c8408d80778cb5dee834f3f17ad85a144ec3775236c44af1/vercel-0.3.8-py3-none-any.whl", hash = "sha256:4e4cebd5e665701eee00e4917a813f00277e4fb37b82c47fb7062e0ab927a6d2", size = 53092, upload-time = "2026-01-20T21:33:26.107Z" },
-]
-
-[[package]]
-name = "vercel-ai-sdk"
-version = "0.0.1.dev10"
-source = { editable = "." }
-dependencies = [
-    { name = "anthropic" },
-    { name = "httpx" },
-    { name = "mcp" },
-    { name = "modelsdotdev" },
-    { name = "openai" },
-    { name = "pydantic" },
-    { name = "typing-extensions" },
-    { name = "vercel" },
-]
-
-[package.dev-dependencies]
-dev = [
-    { name = "async-solipsism" },
-    { name = "mypy" },
-    { name = "pyright" },
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-    { name = "python-dotenv" },
-    { name = "rich" },
-    { name = "ruff" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "anthropic", specifier = ">=0.83.0" },
-    { name = "httpx", specifier = ">=0.28.1" },
-    { name = "mcp", specifier = ">=1.18.0" },
-    { name = "modelsdotdev", git = "https://github.com/vercel-labs/modelsdotdev-python" },
-    { name = "openai", specifier = ">=2.14.0" },
-    { name = "pydantic", specifier = ">=2.12.5" },
-    { name = "typing-extensions", specifier = ">=4.15.0" },
-    { name = "vercel", specifier = ">=0.3.8" },
-]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "async-solipsism", specifier = ">=0.9" },
-    { name = "mypy", specifier = ">=1.11" },
-    { name = "pyright", specifier = ">=1.1.408" },
-    { name = "pytest", specifier = ">=8.0" },
-    { name = "pytest-asyncio", specifier = ">=0.24" },
-    { name = "python-dotenv", specifier = ">=1.2.1" },
-    { name = "rich", specifier = ">=14.2.0" },
-    { name = "ruff", specifier = ">=0.8" },
 ]
 
 [[package]]


### PR DESCRIPTION
The project name is now properly declared as `ai`, Apache 2.0
licensed.  Add some classifiers, make version dynamically derived from
git via hatchling and uv-dynamic-versioning.
