### PR TITLE
docs: show usage budget checks

### DIFF
--- a/docs/ai-python/content/docs/basics/streaming.mdx
+++ b/docs/ai-python/content/docs/basics/streaming.mdx
@@ -54,6 +54,25 @@ usage = stream.usage
 Use `stream.message` when you need to append the assistant turn to your own
 history. Use `stream.text` when you only need the final text.
 
+## Enforce usage budgets
+
+After the stream finishes, `stream.usage` contains the latest normalized token
+usage reported by the provider. You can compare it with your own per-user,
+per-tenant, or per-workflow budget before allowing the next model call:
+
+```python
+MAX_TOKENS = 2_000
+
+async with ai.stream(model, messages) as stream:
+    async for event in stream:
+        if isinstance(event, ai.events.TextDelta):
+            print(event.chunk, end="", flush=True)
+
+usage = stream.usage
+if usage is not None and usage.total_tokens > MAX_TOKENS:
+    raise RuntimeError(f"Token budget exceeded: {usage.total_tokens}")
+```
+
 ## Use structured output
 
 Pass a Pydantic model as `output_type` when you want the final text parsed as

--- a/docs/ai-python/content/docs/core-framework/streams.mdx
+++ b/docs/ai-python/content/docs/core-framework/streams.mdx
@@ -84,6 +84,11 @@ if event.usage is not None:
     print(event.usage)
 ```
 
+Use the final `stream.usage` value for application-level spending controls,
+such as token budgets, tenant quotas, or workflow limits. Providers may omit
+usage, so treat a missing value as an explicit policy decision in your
+application.
+
 ## Replay streams
 
 When the last message has `replay=True`, `ai.stream` does not call the provider.


### PR DESCRIPTION
Summary
- Add a streaming docs example that checks `stream.usage.total_tokens` against an application budget.
- Clarify in the core streams guide that usage can drive app-level token budgets, tenant quotas, and workflow limits.
- Call out that missing provider usage should be handled as an explicit application policy decision.

Why
This keeps rate/spend controls at the application boundary while showing where the SDK exposes provider-normalized usage.

Verification
- `pnpm --dir docs/ai-python install`
- `pnpm --dir docs/ai-python build`
- `git diff --check`

Notes
- `uv run ruff format --check ...` does not support MDX files and fails to parse frontmatter, so I used the docs build as the relevant validation.