### PR TITLE
Remove a bunch of lints I don't like

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,9 +120,9 @@ extend-select = [
     "PIE",  # flake8-pie
     "PLE",  # pylint-error
     "PLW",  # pylint-warning
-    "PLC",  # pylint-convention
+    "PLC0415",  # pylint-convention: import not at top of file
+    "PLC2701",  # pylint-convention: private import
     "RUF",  # ruff specific
-    "SIM",  # flake8-simplify
     "T20",  # flake8-print
     "TC",   # flake8-type-checking
     "UP",   # pyupgrade


### PR DESCRIPTION
Here are some of them:
```
src/ai/types/messages.py:44:5: SIM102 Use a single `if` statement instead of nested `if` statements
   |
42 |       if _is_file_part_dict(value):
43 |           return FilePart.model_validate(value)
44 |       if isinstance(value, list):
   |  _____^
45 | |         if any(_is_file_part_dict(item) for item in value):
   | |___________________________________________________________^ SIM102
46 |               return [
47 |                   FilePart.model_validate(item)
   |
   = help: Combine `if` statements using `and`

src/ai/types/messages.py:87:13: PLC2801 Unnecessary dunder call to `__setattr__`. Mutate attribute directly or use setattr built-in function.
   |
85 |         if rehydrated is not self.result:
86 |             # Bypass frozen protection for post-init fixup.
87 |             object.__setattr__(self, "result", rehydrated)
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PLC2801
88 |         return self
   |
   = help: Mutate attribute directly or use setattr built-in function

tests/providers/ai_gateway/test_protocol.py:452:46: PLC1901 `result["value"][0]["data"] != ""` can be simplified to `result["value"][0]["data"]` as an empty string is falsey
    |
450 |         assert result["value"][0]["type"] == "image-data"
451 |         # Should be base64-encoded
452 |         assert result["value"][0]["data"] != ""
    |                                              ^^ PLC1901
    |
```

I actually might agree with the first one but I don't really want a
linter making that sort of suggestion.
