### PR TITLE
Run ty instead of pyright in runtests

### DIFF
--- a/runtests
+++ b/runtests
@@ -18,8 +18,8 @@ uv run ruff check "${check_args[@]}" src tests examples
 echo "=== mypy ==="
 uv run mypy src tests
 
-echo "=== pyright ==="
-uv run pyright src tests
+echo "=== ty ==="
+uv run ty check
 
 echo "=== pytest ==="
 uv run pytest


### PR DESCRIPTION
Match what we do in CI
