### PR TITLE
Make anthropic's Usage input_tokens include cache_read_tokens

### DIFF
--- a/src/ai/providers/anthropic/protocol.py
+++ b/src/ai/providers/anthropic/protocol.py
@@ -861,12 +861,15 @@ async def stream(
 
             snapshot = sdk_stream.current_message_snapshot
             sdk_usage = snapshot.usage
+            cache_read = getattr(sdk_usage, "cache_read_input_tokens", None)
             usage = types.usage.Usage(
-                input_tokens=sdk_usage.input_tokens or 0,
-                output_tokens=sdk_usage.output_tokens or 0,
-                cache_read_tokens=getattr(
-                    sdk_usage, "cache_read_input_tokens", None
+                # We combine input_tokens and cache_read_input_tokens,
+                # to match the behavior of other providers.
+                input_tokens=(
+                    (sdk_usage.input_tokens or 0) + (cache_read or 0)
                 ),
+                output_tokens=sdk_usage.output_tokens or 0,
+                cache_read_tokens=cache_read,
                 cache_write_tokens=getattr(
                     sdk_usage, "cache_creation_input_tokens", None
                 ),

--- a/src/ai/types/usage.py
+++ b/src/ai/types/usage.py
@@ -15,6 +15,7 @@ class Usage(pydantic.BaseModel):
 
     model_config = pydantic.ConfigDict(frozen=True)
 
+    # input_tokens includes both cached and uncached input tokens.
     input_tokens: int = 0
     output_tokens: int = 0
 


### PR DESCRIPTION
This matches what gateway and openai do.
