### PR TITLE
Add deterministic test model protocol

### DIFF
--- a/src/ai/__init__.py
+++ b/src/ai/__init__.py
@@ -90,6 +90,7 @@ from .models import (
     stream,
 )
 from .providers import get_provider
+from .testing import TestProtocol, TestProvider, test_model
 from .types import events, messages, tools
 from .types.builders import (
     assistant_message,
@@ -163,6 +164,8 @@ __all__ = [
     "StreamingTextTool",
     "SubAgentTool",
     "TemperatureSamplerParams",
+    "TestProtocol",
+    "TestProvider",
     "TokenThreshold",
     "Tool",
     "ToolCall",
@@ -198,6 +201,7 @@ __all__ = [
     "stream",
     "system_message",
     "telemetry",
+    "test_model",
     "text_part",
     "thinking",
     "tool",

--- a/src/ai/testing.py
+++ b/src/ai/testing.py
@@ -1,0 +1,284 @@
+"""Deterministic local model for agent and example tests."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any, Literal
+
+import pydantic
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator, Sequence
+
+from .models.core import model as model_
+from .models.core import params as params_
+from .providers import base
+from .types import events
+from .types import messages as messages_
+from .types import tools as tools_
+
+_CALL_PREFIX = "call:"
+_PING_PREFIX = "ping:"
+_TEXT_BLOCK_ID = "test-text-0"
+_MODEL_ID = "test"
+_DEFAULT_MAX_COMMAND_CHARS = 64 * 1024
+_DEFAULT_MAX_RESULT_CHARS = 1024 * 1024
+_MAX_JSON_NESTING_DEPTH = 64
+_JSON_ADAPTER = pydantic.TypeAdapter(dict[str, Any])
+
+
+class _TestClient:
+    """Credential-free placeholder used by :class:`TestProvider`."""
+
+
+_TEST_CLIENT = _TestClient()
+
+
+def _build_unique_json_object(
+    pairs: list[tuple[str, Any]],
+) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(
+                "call: tool arguments must not contain duplicate JSON keys"
+            )
+        result[key] = value
+    return result
+
+
+def _validate_json_nesting(value: Any) -> None:
+    pending_values = [(value, 1)]
+    while pending_values:
+        current_value, depth = pending_values.pop()
+        if depth > _MAX_JSON_NESTING_DEPTH:
+            raise ValueError("call: tool argument nesting is too deep")
+
+        next_depth = depth + 1
+        if isinstance(current_value, dict):
+            pending_values.extend(
+                (nested_value, next_depth)
+                for nested_value in current_value.values()
+            )
+        elif isinstance(current_value, list):
+            pending_values.extend(
+                (nested_value, next_depth) for nested_value in current_value
+            )
+
+
+def _parse_tool_call(command: str) -> tuple[str, str]:
+    payload = command.removeprefix(_CALL_PREFIX).strip()
+    if not payload:
+        raise ValueError("call: requires a tool name")
+
+    parts = payload.split(maxsplit=1)
+    tool_name = parts[0]
+    if len(parts) == 1:
+        return tool_name, "{}"
+
+    try:
+        tool_args = json.loads(
+            parts[1], object_pairs_hook=_build_unique_json_object
+        )
+    except json.JSONDecodeError as exc:
+        raise ValueError("call: tool arguments must be valid JSON") from exc
+    except RecursionError as exc:
+        raise ValueError("call: tool argument nesting is too deep") from exc
+    if not isinstance(tool_args, dict):
+        raise ValueError("call: tool arguments must be a JSON object")
+    _validate_json_nesting(tool_args)
+    try:
+        serialized = json.dumps(
+            tool_args,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        )
+    except ValueError as exc:
+        raise ValueError("call: tool arguments must be valid JSON") from exc
+    return tool_name, serialized
+
+
+def _validate_tool_name(
+    tool_name: str,
+    tools: Sequence[tools_.Tool] | None,
+) -> None:
+    available_names = sorted(
+        tool.name for tool in tools or () if tool.kind == "function"
+    )
+    if tool_name in available_names:
+        return
+
+    available = ", ".join(available_names) or "none"
+    raise ValueError(
+        f"unknown test tool {tool_name!r}; "
+        f"available function tools: {available}"
+    )
+
+
+def _next_tool_call_id(messages: Sequence[messages_.Message]) -> str:
+    existing_ids = {
+        tool_call.tool_call_id
+        for message in messages
+        for tool_call in message.tool_calls
+    }
+    tool_call_index = 0
+    while True:
+        tool_call_id = f"test-tool-call-{tool_call_index}"
+        if tool_call_id not in existing_ids:
+            return tool_call_id
+        tool_call_index += 1
+
+
+def _format_tool_result(
+    message: messages_.Message,
+    *,
+    max_chars: int,
+) -> str:
+    tool_results = message.tool_results
+    if len(tool_results) != 1:
+        raise ValueError(
+            "test model requires exactly one tool result; "
+            f"received {len(tool_results)}"
+        )
+
+    tool_result = tool_results[0]
+    payload = {
+        "is_error": tool_result.is_error,
+        "result": tool_result.get_model_input(),
+        "tool_call_id": tool_result.tool_call_id,
+        "tool_name": tool_result.tool_name,
+    }
+    try:
+        json_payload = _JSON_ADAPTER.dump_python(payload, mode="json")
+        serialized = json.dumps(
+            json_payload,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        )
+    except (RecursionError, TypeError, ValueError) as exc:
+        raise ValueError(
+            "test model tool result must be JSON serializable"
+        ) from exc
+    if len(serialized) > max_chars:
+        raise ValueError(
+            "test model tool result exceeds max_result_chars "
+            f"({len(serialized)} > {max_chars})"
+        )
+    return f"return: {serialized}"
+
+
+async def _stream_text(text: str) -> AsyncGenerator[events.Event]:
+    yield events.StreamStart()
+    yield events.TextStart(block_id=_TEXT_BLOCK_ID)
+    yield events.TextDelta(block_id=_TEXT_BLOCK_ID, chunk=text)
+    yield events.TextEnd(block_id=_TEXT_BLOCK_ID)
+    yield events.StreamEnd()
+
+
+async def _stream_tool_call(
+    tool_call_id: str,
+    tool_name: str,
+    tool_args: str,
+) -> AsyncGenerator[events.Event]:
+    yield events.StreamStart()
+    yield events.ToolStart(
+        tool_call_id=tool_call_id,
+        tool_name=tool_name,
+    )
+    yield events.ToolDelta(tool_call_id=tool_call_id, chunk=tool_args)
+    yield events.ToolEnd(
+        tool_call_id=tool_call_id,
+        tool_call=messages_.DUMMY_TOOL_CALL,
+    )
+    yield events.StreamEnd()
+
+
+class TestProtocol(base.ProviderProtocol[_TestClient]):
+    """Parse bounded local commands and emit normal model stream events."""
+
+    protocol_class_id: Literal["test_model"] = "test_model"
+    max_command_chars: int = pydantic.Field(
+        default=_DEFAULT_MAX_COMMAND_CHARS,
+        gt=0,
+    )
+    max_result_chars: int = pydantic.Field(
+        default=_DEFAULT_MAX_RESULT_CHARS,
+        gt=0,
+    )
+
+    def stream(
+        self,
+        client: _TestClient,
+        model: model_.Model,
+        messages: list[messages_.Message],
+        *,
+        tools: Sequence[tools_.Tool] | None = None,
+        output_type: type[pydantic.BaseModel] | None = None,
+        params: params_.InferenceRequestParams | None = None,
+        provider: str,
+    ) -> AsyncGenerator[events.Event]:
+        _ = client, model, output_type, params, provider
+        if not messages:
+            raise ValueError("test model requires at least one message")
+
+        latest_message = messages[-1]
+        if latest_message.role == "tool":
+            return _stream_text(
+                _format_tool_result(
+                    latest_message,
+                    max_chars=self.max_result_chars,
+                )
+            )
+        if latest_message.role != "user":
+            raise ValueError(
+                "test model expects a user command or tool result; "
+                f"received role {latest_message.role!r}"
+            )
+
+        command = latest_message.text
+        if len(command) > self.max_command_chars:
+            raise ValueError(
+                "test model command exceeds max_command_chars "
+                f"({len(command)} > {self.max_command_chars})"
+            )
+        if command.startswith(_PING_PREFIX):
+            return _stream_text(f"pong:{command.removeprefix(_PING_PREFIX)}")
+        if command.startswith(_CALL_PREFIX):
+            tool_name, tool_args = _parse_tool_call(command)
+            _validate_tool_name(tool_name, tools)
+            tool_call_id = _next_tool_call_id(messages)
+            return _stream_tool_call(tool_call_id, tool_name, tool_args)
+        raise ValueError(
+            "unsupported test model command; expected 'ping: <text>' or "
+            "'call: <tool> [<json object>]'"
+        )
+
+
+class TestProvider(base.Provider[_TestClient]):
+    """Credential-free provider backed by :class:`TestProtocol`."""
+
+    provider_class_id: Literal["test"] = "test"
+    name: str = "test"
+    default_base_url: str = "test://local"
+
+    def model_post_init(self, __context: Any) -> None:
+        self._set_client(_TEST_CLIENT)
+
+    def default_protocol(self) -> TestProtocol:
+        return TestProtocol()
+
+    async def list_models(self) -> list[str]:
+        return [_MODEL_ID]
+
+    async def probe(self, model: model_.Model) -> None:
+        _ = model
+
+
+def test_model() -> model_.Model:
+    """Create a deterministic local model that requires no credentials."""
+    return model_.Model(id=_MODEL_ID, provider=TestProvider())
+
+
+__all__ = ["TestProtocol", "TestProvider", "test_model"]

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -1,0 +1,220 @@
+from collections.abc import Sequence
+
+import pytest
+
+import ai
+from ai import testing
+
+
+async def _run_model_command(
+    command: str,
+    *,
+    tools: Sequence[ai.tools.Tool] | None = None,
+    model: ai.Model | None = None,
+) -> str:
+    selected_model = model if model is not None else ai.test_model()
+    async with ai.stream(
+        selected_model,
+        [ai.user_message(command)],
+        tools=tools,
+    ) as stream:
+        async for _ in stream:
+            pass
+    return stream.text
+
+
+def test_model_creates_local_provider() -> None:
+    model = ai.test_model()
+
+    assert model.id == "test"
+    assert isinstance(model.provider, testing.TestProvider)
+    assert isinstance(model.provider.protocol, testing.TestProtocol)
+    assert model.provider.api_key is None
+    assert model.provider.is_configured()
+
+
+def test_model_round_trips_through_serialization() -> None:
+    model = ai.test_model()
+
+    restored = ai.Model.model_validate_json(model.model_dump_json())
+
+    assert restored == model
+    assert isinstance(restored.provider, testing.TestProvider)
+
+
+async def test_provider_lists_and_probes_local_model() -> None:
+    model = ai.test_model()
+
+    assert await model.provider.list_models() == ["test"]
+    await model.provider.probe(model)
+
+
+async def test_ping_streams_standard_text_events() -> None:
+    async with ai.stream(
+        ai.test_model(), [ai.user_message("ping: hello")]
+    ) as stream:
+        events = [event async for event in stream]
+
+    assert stream.text == "pong: hello"
+    assert [event.kind for event in events] == [
+        "stream_start",
+        "text_start",
+        "text_delta",
+        "text_end",
+        "stream_end",
+    ]
+    assert stream.message.parts[0].id == "test-text-0"
+
+
+async def test_agent_executes_tool_and_returns_canonical_json() -> None:
+    calls: list[tuple[int, int]] = []
+
+    @ai.tool
+    async def add(left: int, right: int) -> int:
+        calls.append((left, right))
+        return left + right
+
+    agent = ai.Agent(tools=[add])
+    command = 'call: add {"right":3,"left":2}'
+    async with agent.run(ai.test_model(), [ai.user_message(command)]) as stream:
+        events = [event async for event in stream]
+
+    assert calls == [(2, 3)]
+    assert stream.output == (
+        'return: {"is_error":false,"result":5,'
+        '"tool_call_id":"test-tool-call-0","tool_name":"add"}'
+    )
+    tool_end = next(
+        event for event in events if isinstance(event, ai.events.ToolEnd)
+    )
+    assert tool_end.tool_call.tool_args == '{"left":2,"right":3}'
+
+
+async def test_tool_call_identifiers_are_deterministic() -> None:
+    @ai.tool
+    async def ready() -> bool:
+        return True
+
+    tool_call_ids: list[str] = []
+    for _ in range(2):
+        async with ai.stream(
+            ai.test_model(),
+            [ai.user_message("call: ready")],
+            tools=[ready.tool],
+        ) as stream:
+            async for _ in stream:
+                pass
+        tool_call_ids.append(stream.tool_calls[0].tool_call_id)
+        assert stream.tool_calls[0].tool_args == "{}"
+
+    assert tool_call_ids == ["test-tool-call-0", "test-tool-call-0"]
+
+
+async def test_tool_call_identifiers_are_unique_within_history() -> None:
+    @ai.tool
+    async def ready() -> bool:
+        return True
+
+    agent = ai.Agent(tools=[ready])
+    model = ai.test_model()
+    messages = [ai.user_message("call: ready")]
+
+    for _ in range(2):
+        async with agent.run(model, messages) as stream:
+            async for _ in stream:
+                pass
+        messages = [*stream.messages, ai.user_message("call: ready")]
+
+    tool_call_ids = [
+        tool_call.tool_call_id
+        for message in stream.messages
+        for tool_call in message.tool_calls
+    ]
+    assert tool_call_ids == ["test-tool-call-0", "test-tool-call-1"]
+
+
+async def test_unknown_tool_fails_with_available_tools() -> None:
+    @ai.tool
+    async def available() -> None:
+        return None
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "unknown test tool 'missing'; "
+            "available function tools: available"
+        ),
+    ):
+        await _run_model_command("call: missing", tools=[available.tool])
+
+
+@pytest.mark.parametrize(
+    ("command", "error"),
+    [
+        ("call:", "call: requires a tool name"),
+        ("call: available {invalid}", "arguments must be valid JSON"),
+        ('call: available {"value":NaN}', "arguments must be valid JSON"),
+        (
+            'call: available {"value":1,"value":2}',
+            "must not contain duplicate JSON keys",
+        ),
+        ("call: available []", "arguments must be a JSON object"),
+        ("hello", "unsupported test model command"),
+    ],
+)
+async def test_invalid_command_fails_loudly(
+    command: str,
+    error: str,
+) -> None:
+    @ai.tool
+    async def available() -> None:
+        return None
+
+    with pytest.raises(ValueError, match=error):
+        await _run_model_command(command, tools=[available.tool])
+
+
+async def test_deeply_nested_json_fails_clearly() -> None:
+    @ai.tool
+    async def available() -> None:
+        return None
+
+    nested_value = "[" * 2000 + "0" + "]" * 2000
+    command = f'call: available {{"value":{nested_value}}}'
+    with pytest.raises(ValueError, match="argument nesting is too deep"):
+        await _run_model_command(command, tools=[available.tool])
+
+
+async def test_command_size_is_bounded() -> None:
+    protocol = testing.TestProtocol(max_command_chars=8)
+    model = ai.test_model().with_protocol(protocol)
+
+    with pytest.raises(ValueError, match="exceeds max_command_chars"):
+        await _run_model_command("ping: 123", model=model)
+
+
+async def test_tool_result_size_is_bounded() -> None:
+    protocol = testing.TestProtocol(max_result_chars=1)
+    model = ai.test_model().with_protocol(protocol)
+    tool_call_message = ai.assistant_message(
+        ai.messages.ToolCallPart(
+            tool_call_id="test-tool-call-0",
+            tool_name="large_result",
+            tool_args="{}",
+        )
+    )
+    tool_message = ai.tool_message(
+        tool_call_id="test-tool-call-0",
+        tool_name="large_result",
+        result="too large",
+    )
+    messages = [
+        ai.user_message("call: large_result"),
+        tool_call_message,
+        tool_message,
+    ]
+
+    with pytest.raises(ValueError, match="exceeds max_result_chars"):
+        async with ai.stream(model, messages) as stream:
+            async for _ in stream:
+                pass


### PR DESCRIPTION
Addresses #46.

Adds a test model that speaks the protocol from the issue: `ping: blah` returns `pong: blah`, and `call: add {"left":2,"right":3}` runs the tool through the real `Agent` and replies with `return: <json>`. No API key or network, so examples can be tested end-to-end in CI. `test_model()` is the public helper. pytest, ruff, mypy, and ty all pass. Happy to adjust.