### PR TITLE
Improve instrumentation and gen_ai spec adherence

### DIFF
--- a/src/ai/agents/agent.py
+++ b/src/ai/agents/agent.py
@@ -631,9 +631,11 @@ class BoundToolCall:
 
     async def __call__(self, **overrides: Any) -> events_.ToolCallResult:
         """Execute the tool and return a :class:`ToolCallResult`."""
+        spec = self._tool.tool.spec
         data = telemetry.ToolExecutionSpanData(
             tool_name=self._part.tool_name,
             tool_call_id=self._part.tool_call_id,
+            tool_description=spec.description if spec is not None else None,
         )
 
         # Replay-from-deferred-hook short-circuit: if a prior run already
@@ -1453,6 +1455,7 @@ class Agent:
                     params=params,
                 )
             ) as sp:
+                initial_count = len(context.messages)
                 mw_token: middleware_.Token | None = None
                 if _middleware is not None:
                     parent = middleware_.get()
@@ -1485,6 +1488,15 @@ class Agent:
                         ),
                         None,
                     )
+                    total: types.usage.Usage | None = None
+                    for msg in context.messages[initial_count:]:
+                        if msg.usage is not None:
+                            total = (
+                                msg.usage
+                                if total is None
+                                else total + msg.usage
+                            )
+                    sp.data.usage = total
 
         async with (
             hooks_.use_hook_registry(registry),

--- a/src/ai/experimental_telemetry/otel.py
+++ b/src/ai/experimental_telemetry/otel.py
@@ -11,6 +11,15 @@ Follows the ``gen_ai`` semantic conventions.
 
 There's a certain amount of jank in this adapter, because we want it to work in
 the durable execution case, which conflicts with the OTel spec.
+
+Message content (``gen_ai.input.messages``, ``gen_ai.output.messages``,
+``gen_ai.system_instructions``, ``gen_ai.tool.definitions``, tool call
+arguments and results) is Opt-In in the conventions and off by default:
+pass ``capture_content=True`` or set the standard
+``OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT`` environment
+variable (``true``, ``span_only``, or ``span_and_event``) to emit it.
+Content is emitted in the semconv message shape (role + typed ``parts``
+as a JSON string), not the framework's native message model.
 """
 
 from __future__ import annotations
@@ -20,13 +29,11 @@ import contextvars
 import hashlib
 import json
 import logging
+import os
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
-
-import pydantic
 
 from .. import errors
 from .. import experimental_telemetry as telemetry
-from ..types import messages as messages_
 
 try:
     import opentelemetry.context
@@ -42,14 +49,18 @@ except ModuleNotFoundError as exc:  # pragma: no cover
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator
 
+    from ..types import messages as messages_
+    from ..types import usage as usage_
+
 logger = logging.getLogger(__name__)
 
-_MESSAGES_ADAPTER = pydantic.TypeAdapter(list[messages_.Message])
+
+CAPTURE_CONTENT_ENV = "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT"
 
 
-def _messages_json(messages: list[messages_.Message]) -> str:
-    # turn messages into a string to put it into an otel attribute
-    return _MESSAGES_ADAPTER.dump_json(messages).decode()
+def _capture_content_from_env() -> bool:
+    value = os.environ.get(CAPTURE_CONTENT_ENV, "")
+    return value.strip().lower() in ("true", "span_only", "span_and_event")
 
 
 def _name(sp: telemetry.Span) -> str:
@@ -66,43 +77,315 @@ def _name(sp: telemetry.Span) -> str:
             return sp.name
 
 
-def _attributes(sp: telemetry.Span) -> dict[str, Any]:
+def _kind(sp: telemetry.Span) -> opentelemetry.trace.SpanKind:
+    # Inference spans SHOULD be CLIENT per semconv; agent and tool
+    # spans run in-process and stay INTERNAL.
+    match sp.data:
+        case telemetry.AiStreamSpanData() | telemetry.AiGenerateSpanData():
+            return opentelemetry.trace.SpanKind.CLIENT
+        case _:
+            return opentelemetry.trace.SpanKind.INTERNAL
+
+
+def _json_or_raw(raw: str) -> Any:
+    try:
+        return json.loads(raw)
+    except ValueError:
+        return raw
+
+
+def _semconv_part(part: dict[str, Any]) -> dict[str, Any]:
+    """Map one dumped message part onto its gen_ai semconv shape.
+
+    Shapes per ``docs/gen-ai/non-normative/models.py`` in the semconv
+    repo.  Unknown kinds degrade to the catch-all generic part, which
+    carries only ``type``.
+    """
+    match part["kind"]:
+        case "text":
+            return {"type": "text", "content": part["text"]}
+        case "reasoning":
+            return {"type": "reasoning", "content": part["text"]}
+        case "tool_call":
+            return {
+                "type": "tool_call",
+                "id": part["tool_call_id"],
+                "name": part["tool_name"],
+                "arguments": _json_or_raw(part["tool_args"]),
+            }
+        case "tool_result":
+            return {
+                "type": "tool_call_response",
+                "id": part["tool_call_id"],
+                "response": part["result"],
+            }
+        case "builtin_tool_call":
+            return {
+                "type": "server_tool_call",
+                "id": part["tool_call_id"],
+                "name": part["tool_name"],
+                "server_tool_call": {
+                    "type": part["tool_name"],
+                    "arguments": _json_or_raw(part["tool_args"]),
+                },
+            }
+        case "builtin_tool_return":
+            return {
+                "type": "server_tool_call_response",
+                "id": part["tool_call_id"],
+                "server_tool_call_response": {
+                    "type": part["tool_name"],
+                    "response": part["result"],
+                },
+            }
+        case "file":
+            media_type = part["media_type"]
+            modality = media_type.split("/")[0]
+            if modality not in ("image", "video", "audio"):
+                modality = "document"
+            # data is a str after the JSON dump: a URL or base-64
+            # content.
+            if part["data"].startswith(("http://", "https://")):
+                return {
+                    "type": "uri",
+                    "modality": modality,
+                    "mime_type": media_type,
+                    "uri": part["data"],
+                }
+            return {
+                "type": "blob",
+                "modality": modality,
+                "mime_type": media_type,
+                "content": part["data"],
+            }
+        case kind:
+            return {"type": kind}
+
+
+def _semconv_parts(
+    message: messages_.Message,
+) -> tuple[str, list[dict[str, Any]]]:
+    dumped = message.model_dump(mode="json", fallback=str)
+    return dumped["role"], [_semconv_part(p) for p in dumped["parts"]]
+
+
+def _content_attributes(
+    messages: list[messages_.Message],
+    output: messages_.Message | None,
+    *,
+    error: bool,
+) -> dict[str, str]:
+    """gen_ai message content attributes, in the semconv message shape.
+
+    System messages are excluded from ``input.messages`` and carried as
+    ``gen_ai.system_instructions`` (a flat parts list), per semconv.
+    The schema requires ``finish_reason`` on output messages but the
+    span data doesn't capture it yet (see NEW_DATA_CAPTURE.md), so it
+    is inferred: ``error`` when the span errored, ``tool_call`` when
+    the output requests a tool call, ``stop`` otherwise.
+    """
+    system_parts: list[dict[str, Any]] = []
+    inputs: list[dict[str, Any]] = []
+    for message in messages:
+        role, parts = _semconv_parts(message)
+        if role == "system":
+            system_parts += parts
+        else:
+            inputs.append({"role": role, "parts": parts})
+    attrs = {"gen_ai.input.messages": json.dumps(inputs)}
+    if system_parts:
+        attrs["gen_ai.system_instructions"] = json.dumps(system_parts)
+    if output is not None:
+        role, parts = _semconv_parts(output)
+        if error:
+            finish = "error"
+        elif any(p["type"] == "tool_call" for p in parts):
+            finish = "tool_call"
+        else:
+            finish = "stop"
+        attrs["gen_ai.output.messages"] = json.dumps(
+            [{"role": role, "parts": parts, "finish_reason": finish}]
+        )
+    return attrs
+
+
+def _field(obj: Any, name: str) -> Any:
+    # Params are ``Any`` on span data: live params objects in-process,
+    # plain dicts after a JSON round-trip.  Read both.
+    if isinstance(obj, dict):
+        return obj.get(name)
+    return getattr(obj, name, None)
+
+
+def _has_field(obj: Any, name: str) -> bool:
+    if isinstance(obj, dict):
+        return name in obj
+    return hasattr(obj, name)
+
+
+_SEMCONV_SAMPLER_FIELDS = (
+    "temperature",
+    "top_k",
+    "top_p",
+    "frequency_penalty",
+    "presence_penalty",
+    "seed",
+)
+
+
+def _request_attributes(params: Any) -> dict[str, Any]:
+    """``gen_ai.request.*`` attributes from inference params.
+
+    Only numeric, explicitly-set values come through: provider-default
+    sentinels and framework knobs with no semconv name (``min_p``,
+    ``repetition_penalty``, ...) are skipped.
+    """
+    attrs: dict[str, Any] = {}
+    sampling = _field(params, "sampling")
+    if isinstance(sampling, dict):
+        for sampler in sampling.values():
+            for name in _SEMCONV_SAMPLER_FIELDS:
+                value = _field(sampler, name)
+                if isinstance(value, int | float) and not isinstance(
+                    value, bool
+                ):
+                    attrs[f"gen_ai.request.{name}"] = value
+    max_tokens = _field(_field(params, "output"), "max_tokens")
+    if isinstance(max_tokens, int):
+        attrs["gen_ai.request.max_tokens"] = max_tokens
+    effort = _field(_field(params, "reasoning"), "effort")
+    if isinstance(effort, str):
+        attrs["gen_ai.request.reasoning.level"] = effort
+    return attrs
+
+
+def _usage_attributes(usage: usage_.Usage) -> dict[str, Any]:
+    attrs: dict[str, Any] = {
+        "gen_ai.usage.input_tokens": usage.input_tokens,
+        "gen_ai.usage.output_tokens": usage.output_tokens,
+    }
+    if usage.reasoning_tokens is not None:
+        attrs["gen_ai.usage.reasoning.output_tokens"] = usage.reasoning_tokens
+    if usage.cache_read_tokens is not None:
+        attrs["gen_ai.usage.cache_read.input_tokens"] = usage.cache_read_tokens
+    if usage.cache_write_tokens is not None:
+        attrs["gen_ai.usage.cache_creation.input_tokens"] = (
+            usage.cache_write_tokens
+        )
+    return attrs
+
+
+def _provider_name(model: str, provider: str | None) -> str | None:
+    # Gateway model ids are "provider/model"; the prefix names the
+    # actual inference provider and matches semconv's well-known values
+    # better than the framework provider adapter's name.
+    if "/" in model:
+        return model.partition("/")[0]
+    return provider
+
+
+def _time_to_first_chunk(sp: telemetry.Span) -> float | None:
+    if sp.started_at is None:
+        return None
+    for event in sp.events:
+        if event.name == telemetry.FIRST_TOKEN:
+            return (event.time_ns - sp.started_at) / 1e9
+    return None
+
+
+def _tool_definitions(names: list[str]) -> str:
+    return json.dumps([{"type": "function", "name": n} for n in names])
+
+
+def _attributes(sp: telemetry.Span, *, capture_content: bool) -> dict[str, Any]:
     attrs: dict[str, Any] = {}
     if sp.replay:
         attrs["ai.replay"] = True
     match sp.data:
         case telemetry.AiStreamSpanData() as d:
             attrs["gen_ai.operation.name"] = "chat"
+            provider = _provider_name(d.model, d.provider)
+            if provider is not None:
+                attrs["gen_ai.provider.name"] = provider
             attrs["gen_ai.request.model"] = d.model
-            attrs["gen_ai.input.messages"] = _messages_json(d.messages)
-            if d.message is not None:
-                attrs["gen_ai.output.messages"] = _messages_json([d.message])
+            attrs["gen_ai.request.stream"] = True
+            attrs |= _request_attributes(d.params)
+            ttfc = _time_to_first_chunk(sp)
+            if ttfc is not None:
+                attrs["gen_ai.response.time_to_first_chunk"] = ttfc
             if d.usage is not None:
-                attrs["gen_ai.usage.input_tokens"] = d.usage.input_tokens
-                attrs["gen_ai.usage.output_tokens"] = d.usage.output_tokens
+                attrs |= _usage_attributes(d.usage)
+            if capture_content:
+                if d.tool_names:
+                    attrs["gen_ai.tool.definitions"] = _tool_definitions(
+                        d.tool_names
+                    )
+                attrs |= _content_attributes(
+                    d.messages, d.message, error=sp.error is not None
+                )
         case telemetry.AiGenerateSpanData() as d:
             attrs["gen_ai.operation.name"] = "generate_content"
+            provider = _provider_name(d.model, d.provider)
+            if provider is not None:
+                attrs["gen_ai.provider.name"] = provider
             attrs["gen_ai.request.model"] = d.model
-            if d.message is not None:
-                attrs["gen_ai.output.messages"] = _messages_json([d.message])
+            n = _field(d.params, "n")
+            if isinstance(n, int) and n != 1:
+                attrs["gen_ai.request.choice.count"] = n
+            seed = _field(d.params, "seed")
+            if isinstance(seed, int):
+                attrs["gen_ai.request.seed"] = seed
+            if d.params is not None:
+                # ImageParams vs VideoParams: only the latter has fps.
+                attrs["gen_ai.output.type"] = (
+                    "video" if _has_field(d.params, "fps") else "image"
+                )
+            if d.usage is not None:
+                attrs |= _usage_attributes(d.usage)
+            if capture_content:
+                attrs |= _content_attributes(
+                    d.messages, d.message, error=sp.error is not None
+                )
         case telemetry.ToolExecutionSpanData() as d:
             attrs["gen_ai.operation.name"] = "execute_tool"
             attrs["gen_ai.tool.name"] = d.tool_name
+            attrs["gen_ai.tool.type"] = "function"
             attrs["gen_ai.tool.call.id"] = d.tool_call_id
-            if d.args is not None:
-                attrs["gen_ai.tool.call.arguments"] = json.dumps(
-                    d.args, default=str
-                )
-            if d.result is not None:
-                attrs["gen_ai.tool.call.result"] = json.dumps(
-                    d.result, default=str
-                )
             if d.is_error:
-                attrs["ai.tool.is_error"] = True
+                # The exception type is not captured when the error is
+                # only a model-facing result (see NEW_DATA_CAPTURE.md);
+                # ``_OTHER`` is semconv's fallback class.  Overwritten
+                # with the real type when the span carries an error.
+                attrs["error.type"] = "_OTHER"
+            if capture_content:
+                if d.args is not None:
+                    attrs["gen_ai.tool.call.arguments"] = json.dumps(
+                        d.args, default=str
+                    )
+                if d.result is not None:
+                    attrs["gen_ai.tool.call.result"] = json.dumps(
+                        d.result, default=str
+                    )
         case telemetry.RunSpanData() as d:
             attrs["gen_ai.operation.name"] = "invoke_agent"
             attrs["gen_ai.agent.name"] = d.agent
+            provider = _provider_name(d.model, d.provider)
+            if provider is not None:
+                attrs["gen_ai.provider.name"] = provider
             attrs["gen_ai.request.model"] = d.model
+            if d.output_type is not None:
+                # Structured output was requested; the semconv value is
+                # the output kind, not the Python type name.
+                attrs["gen_ai.output.type"] = "json"
+            attrs |= _request_attributes(d.params)
+            if capture_content:
+                if d.tool_names:
+                    attrs["gen_ai.tool.definitions"] = _tool_definitions(
+                        d.tool_names
+                    )
+                attrs |= _content_attributes(
+                    d.messages, d.final_message, error=sp.error is not None
+                )
         case telemetry.HookSpanData() as d:
             attrs["ai.hook.label"] = d.label
             attrs["ai.hook.type"] = d.hook_type
@@ -180,10 +463,17 @@ class OtelAdapter(telemetry.Adapter):
         self,
         *,
         tracer_provider: opentelemetry.trace.TracerProvider | None = None,
+        capture_content: bool | None = None,
     ) -> None:
         provider = tracer_provider or opentelemetry.trace.get_tracer_provider()
         self._provider = provider
         self._live: dict[str, opentelemetry.trace.Span] = {}
+
+        self._capture_content = (
+            _capture_content_from_env()
+            if capture_content is None
+            else capture_content
+        )
 
         self._is_smuggling_ids = False
         # printed a warning once when failing to smuggle ids
@@ -211,7 +501,7 @@ class OtelAdapter(telemetry.Adapter):
                 def span_attributes(self, span_):
                     return super().span_attributes(span_) | {"k": "v"}
         """
-        return _attributes(span_)
+        return _attributes(span_, capture_content=self._capture_content)
 
     def flush(self) -> None:
         """Flush the provider's exporters."""
@@ -278,6 +568,7 @@ class OtelAdapter(telemetry.Adapter):
             otel_span = self._tracer.start_span(
                 self.span_name(span_),
                 context=parent_context,
+                kind=_kind(span_),
                 start_time=span_.started_at,
             )
         finally:
@@ -317,6 +608,7 @@ class OtelAdapter(telemetry.Adapter):
             for key, value in self.span_attributes(span_).items():
                 otel_span.set_attribute(key, value)
             if span_.error is not None:
+                otel_span.set_attribute("error.type", span_.error.type)
                 otel_span.set_status(
                     opentelemetry.trace.StatusCode.ERROR,
                     f"{span_.error.type}: {span_.error.message}",
@@ -325,12 +617,20 @@ class OtelAdapter(telemetry.Adapter):
 
 
 def install(
-    *, tracer_provider: opentelemetry.trace.TracerProvider | None = None
+    *,
+    tracer_provider: opentelemetry.trace.TracerProvider | None = None,
+    capture_content: bool | None = None,
 ) -> OtelAdapter:
     """Create the otel adapter, register it, and return it.
 
-    Uses the global tracer provider unless one is passed.
+    Uses the global tracer provider unless one is passed.  Message
+    content capture is off by default, per the gen_ai conventions;
+    ``capture_content=True`` (or the
+    ``OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT`` environment
+    variable) turns it on.
     """
-    adapter = OtelAdapter(tracer_provider=tracer_provider)
+    adapter = OtelAdapter(
+        tracer_provider=tracer_provider, capture_content=capture_content
+    )
     telemetry.register(adapter)
     return adapter

--- a/src/ai/experimental_telemetry/otel.py
+++ b/src/ai/experimental_telemetry/otel.py
@@ -174,14 +174,15 @@ def _content_attributes(
     output: messages_.Message | None,
     *,
     error: bool,
+    finish_reason: str | None = None,
 ) -> dict[str, str]:
     """gen_ai message content attributes, in the semconv message shape.
 
     System messages are excluded from ``input.messages`` and carried as
     ``gen_ai.system_instructions`` (a flat parts list), per semconv.
-    The schema requires ``finish_reason`` on output messages but the
-    span data doesn't capture it yet (see NEW_DATA_CAPTURE.md), so it
-    is inferred: ``error`` when the span errored, ``tool_call`` when
+    The schema requires ``finish_reason`` on output messages; when the
+    span data doesn't carry one (replay, spans recorded before capture)
+    it is inferred: ``error`` when the span errored, ``tool_call`` when
     the output requests a tool call, ``stop`` otherwise.
     """
     system_parts: list[dict[str, Any]] = []
@@ -197,7 +198,9 @@ def _content_attributes(
         attrs["gen_ai.system_instructions"] = json.dumps(system_parts)
     if output is not None:
         role, parts = _semconv_parts(output)
-        if error:
+        if finish_reason is not None:
+            finish = finish_reason
+        elif error:
             finish = "error"
         elif any(p["type"] == "tool_call" for p in parts):
             finish = "tool_call"
@@ -309,10 +312,20 @@ def _attributes(sp: telemetry.Span, *, capture_content: bool) -> dict[str, Any]:
                 attrs["gen_ai.provider.name"] = provider
             attrs["gen_ai.request.model"] = d.model
             attrs["gen_ai.request.stream"] = True
+            if d.output_type is not None:
+                # Structured output was requested; the semconv value is
+                # the output kind, not the Python type name.
+                attrs["gen_ai.output.type"] = "json"
             attrs |= _request_attributes(d.params)
             ttfc = _time_to_first_chunk(sp)
             if ttfc is not None:
                 attrs["gen_ai.response.time_to_first_chunk"] = ttfc
+            if d.finish_reason is not None:
+                attrs["gen_ai.response.finish_reasons"] = [d.finish_reason]
+            if d.response_id is not None:
+                attrs["gen_ai.response.id"] = d.response_id
+            if d.response_model is not None:
+                attrs["gen_ai.response.model"] = d.response_model
             if d.usage is not None:
                 attrs |= _usage_attributes(d.usage)
             if capture_content:
@@ -321,7 +334,10 @@ def _attributes(sp: telemetry.Span, *, capture_content: bool) -> dict[str, Any]:
                         d.tool_names
                     )
                 attrs |= _content_attributes(
-                    d.messages, d.message, error=sp.error is not None
+                    d.messages,
+                    d.message,
+                    error=sp.error is not None,
+                    finish_reason=d.finish_reason,
                 )
         case telemetry.AiGenerateSpanData() as d:
             attrs["gen_ai.operation.name"] = "generate_content"
@@ -351,6 +367,8 @@ def _attributes(sp: telemetry.Span, *, capture_content: bool) -> dict[str, Any]:
             attrs["gen_ai.tool.name"] = d.tool_name
             attrs["gen_ai.tool.type"] = "function"
             attrs["gen_ai.tool.call.id"] = d.tool_call_id
+            if d.tool_description is not None:
+                attrs["gen_ai.tool.description"] = d.tool_description
             if d.is_error:
                 # The exception type is not captured when the error is
                 # only a model-facing result (see NEW_DATA_CAPTURE.md);
@@ -378,6 +396,8 @@ def _attributes(sp: telemetry.Span, *, capture_content: bool) -> dict[str, Any]:
                 # the output kind, not the Python type name.
                 attrs["gen_ai.output.type"] = "json"
             attrs |= _request_attributes(d.params)
+            if d.usage is not None:
+                attrs |= _usage_attributes(d.usage)
             if capture_content:
                 if d.tool_names:
                     attrs["gen_ai.tool.definitions"] = _tool_definitions(

--- a/src/ai/experimental_telemetry/otel.py
+++ b/src/ai/experimental_telemetry/otel.py
@@ -12,14 +12,8 @@ Follows the ``gen_ai`` semantic conventions.
 There's a certain amount of jank in this adapter, because we want it to work in
 the durable execution case, which conflicts with the OTel spec.
 
-Message content (``gen_ai.input.messages``, ``gen_ai.output.messages``,
-``gen_ai.system_instructions``, ``gen_ai.tool.definitions``, tool call
-arguments and results) is Opt-In in the conventions and off by default:
-pass ``capture_content=True`` or set the standard
-``OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT`` environment
-variable (``true``, ``span_only``, or ``span_and_event``) to emit it.
-Content is emitted in the semconv message shape (role + typed ``parts``
-as a JSON string), not the framework's native message model.
+Messages are emitted in the semconv shape for maximum downstream compatibility.
+Capturing message content is opt-in.
 """
 
 from __future__ import annotations
@@ -55,15 +49,16 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+# standard flag for capturing message content
 CAPTURE_CONTENT_ENV = "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT"
 
 
-def _capture_content_from_env() -> bool:
+def _should_capture_content() -> bool:
     value = os.environ.get(CAPTURE_CONTENT_ENV, "")
     return value.strip().lower() in ("true", "span_only", "span_and_event")
 
 
-def _name(sp: telemetry.Span) -> str:
+def _semconv_name(sp: telemetry.Span) -> str:
     match sp.data:
         case telemetry.AiStreamSpanData() as d:
             return f"chat {d.model}"
@@ -77,7 +72,7 @@ def _name(sp: telemetry.Span) -> str:
             return sp.name
 
 
-def _kind(sp: telemetry.Span) -> opentelemetry.trace.SpanKind:
+def _semconv_kind(sp: telemetry.Span) -> opentelemetry.trace.SpanKind:
     # Inference spans SHOULD be CLIENT per semconv; agent and tool
     # spans run in-process and stay INTERNAL.
     match sp.data:
@@ -87,7 +82,7 @@ def _kind(sp: telemetry.Span) -> opentelemetry.trace.SpanKind:
             return opentelemetry.trace.SpanKind.INTERNAL
 
 
-def _json_or_raw(raw: str) -> Any:
+def _maybe_json_loads(raw: str) -> Any:
     try:
         return json.loads(raw)
     except ValueError:
@@ -95,11 +90,9 @@ def _json_or_raw(raw: str) -> Any:
 
 
 def _semconv_part(part: dict[str, Any]) -> dict[str, Any]:
-    """Map one dumped message part onto its gen_ai semconv shape.
+    """Convert part to gen_ai semconv shape.
 
-    Shapes per ``docs/gen-ai/non-normative/models.py`` in the semconv
-    repo.  Unknown kinds degrade to the catch-all generic part, which
-    carries only ``type``.
+    https://github.com/open-telemetry/semantic-conventions-genai/blob/main/docs/gen-ai/non-normative/models.py
     """
     match part["kind"]:
         case "text":
@@ -111,7 +104,7 @@ def _semconv_part(part: dict[str, Any]) -> dict[str, Any]:
                 "type": "tool_call",
                 "id": part["tool_call_id"],
                 "name": part["tool_name"],
-                "arguments": _json_or_raw(part["tool_args"]),
+                "arguments": _maybe_json_loads(part["tool_args"]),
             }
         case "tool_result":
             return {
@@ -126,7 +119,7 @@ def _semconv_part(part: dict[str, Any]) -> dict[str, Any]:
                 "name": part["tool_name"],
                 "server_tool_call": {
                     "type": part["tool_name"],
-                    "arguments": _json_or_raw(part["tool_args"]),
+                    "arguments": _maybe_json_loads(part["tool_args"]),
                 },
             }
         case "builtin_tool_return":
@@ -169,27 +162,20 @@ def _semconv_parts(
     return dumped["role"], [_semconv_part(p) for p in dumped["parts"]]
 
 
-def _content_attributes(
+def _semconv_content_attributes(
     messages: list[messages_.Message],
     output: messages_.Message | None,
     *,
     error: bool,
     finish_reason: str | None = None,
 ) -> dict[str, str]:
-    """gen_ai message content attributes, in the semconv message shape.
-
-    System messages are excluded from ``input.messages`` and carried as
-    ``gen_ai.system_instructions`` (a flat parts list), per semconv.
-    The schema requires ``finish_reason`` on output messages; when the
-    span data doesn't carry one (replay, spans recorded before capture)
-    it is inferred: ``error`` when the span errored, ``tool_call`` when
-    the output requests a tool call, ``stop`` otherwise.
-    """
+    """Extract and convert message content attributes."""
     system_parts: list[dict[str, Any]] = []
     inputs: list[dict[str, Any]] = []
     for message in messages:
         role, parts = _semconv_parts(message)
         if role == "system":
+            # these live in gen_ai.system_instructions
             system_parts += parts
         else:
             inputs.append({"role": role, "parts": parts})
@@ -212,15 +198,15 @@ def _content_attributes(
     return attrs
 
 
-def _field(obj: Any, name: str) -> Any:
-    # Params are ``Any`` on span data: live params objects in-process,
-    # plain dicts after a JSON round-trip.  Read both.
+def _hack_get_field(obj: Any, name: str) -> Any:
+    # this is caused by the params import hack in span.py
     if isinstance(obj, dict):
         return obj.get(name)
     return getattr(obj, name, None)
 
 
-def _has_field(obj: Any, name: str) -> bool:
+def _hack_has_field(obj: Any, name: str) -> bool:
+    # this also
     if isinstance(obj, dict):
         return name in obj
     return hasattr(obj, name)
@@ -236,33 +222,30 @@ _SEMCONV_SAMPLER_FIELDS = (
 )
 
 
-def _request_attributes(params: Any) -> dict[str, Any]:
-    """``gen_ai.request.*`` attributes from inference params.
-
-    Only numeric, explicitly-set values come through: provider-default
-    sentinels and framework knobs with no semconv name (``min_p``,
-    ``repetition_penalty``, ...) are skipped.
-    """
+def _semconv_request_attributes(params: Any) -> dict[str, Any]:
+    """Extract and convert request attributes from inference params."""
     attrs: dict[str, Any] = {}
-    sampling = _field(params, "sampling")
+    sampling = _hack_get_field(params, "sampling")
     if isinstance(sampling, dict):
         for sampler in sampling.values():
             for name in _SEMCONV_SAMPLER_FIELDS:
-                value = _field(sampler, name)
+                value = _hack_get_field(sampler, name)
                 if isinstance(value, int | float) and not isinstance(
                     value, bool
                 ):
                     attrs[f"gen_ai.request.{name}"] = value
-    max_tokens = _field(_field(params, "output"), "max_tokens")
+    max_tokens = _hack_get_field(
+        _hack_get_field(params, "output"), "max_tokens"
+    )
     if isinstance(max_tokens, int):
         attrs["gen_ai.request.max_tokens"] = max_tokens
-    effort = _field(_field(params, "reasoning"), "effort")
+    effort = _hack_get_field(_hack_get_field(params, "reasoning"), "effort")
     if isinstance(effort, str):
         attrs["gen_ai.request.reasoning.level"] = effort
     return attrs
 
 
-def _usage_attributes(usage: usage_.Usage) -> dict[str, Any]:
+def _semconv_usage_attributes(usage: usage_.Usage) -> dict[str, Any]:
     attrs: dict[str, Any] = {
         "gen_ai.usage.input_tokens": usage.input_tokens,
         "gen_ai.usage.output_tokens": usage.output_tokens,
@@ -278,15 +261,6 @@ def _usage_attributes(usage: usage_.Usage) -> dict[str, Any]:
     return attrs
 
 
-def _provider_name(model: str, provider: str | None) -> str | None:
-    # Gateway model ids are "provider/model"; the prefix names the
-    # actual inference provider and matches semconv's well-known values
-    # better than the framework provider adapter's name.
-    if "/" in model:
-        return model.partition("/")[0]
-    return provider
-
-
 def _time_to_first_chunk(sp: telemetry.Span) -> float | None:
     if sp.started_at is None:
         return None
@@ -296,7 +270,7 @@ def _time_to_first_chunk(sp: telemetry.Span) -> float | None:
     return None
 
 
-def _tool_definitions(names: list[str]) -> str:
+def _semconv_tool_definitions(names: list[str]) -> str:
     return json.dumps([{"type": "function", "name": n} for n in names])
 
 
@@ -307,16 +281,15 @@ def _attributes(sp: telemetry.Span, *, capture_content: bool) -> dict[str, Any]:
     match sp.data:
         case telemetry.AiStreamSpanData() as d:
             attrs["gen_ai.operation.name"] = "chat"
-            provider = _provider_name(d.model, d.provider)
-            if provider is not None:
-                attrs["gen_ai.provider.name"] = provider
+            if d.provider is not None:
+                attrs["gen_ai.provider.name"] = d.provider
             attrs["gen_ai.request.model"] = d.model
             attrs["gen_ai.request.stream"] = True
             if d.output_type is not None:
                 # Structured output was requested; the semconv value is
                 # the output kind, not the Python type name.
                 attrs["gen_ai.output.type"] = "json"
-            attrs |= _request_attributes(d.params)
+            attrs |= _semconv_request_attributes(d.params)
             ttfc = _time_to_first_chunk(sp)
             if ttfc is not None:
                 attrs["gen_ai.response.time_to_first_chunk"] = ttfc
@@ -327,13 +300,13 @@ def _attributes(sp: telemetry.Span, *, capture_content: bool) -> dict[str, Any]:
             if d.response_model is not None:
                 attrs["gen_ai.response.model"] = d.response_model
             if d.usage is not None:
-                attrs |= _usage_attributes(d.usage)
+                attrs |= _semconv_usage_attributes(d.usage)
             if capture_content:
                 if d.tool_names:
-                    attrs["gen_ai.tool.definitions"] = _tool_definitions(
-                        d.tool_names
+                    attrs["gen_ai.tool.definitions"] = (
+                        _semconv_tool_definitions(d.tool_names)
                     )
-                attrs |= _content_attributes(
+                attrs |= _semconv_content_attributes(
                     d.messages,
                     d.message,
                     error=sp.error is not None,
@@ -341,25 +314,24 @@ def _attributes(sp: telemetry.Span, *, capture_content: bool) -> dict[str, Any]:
                 )
         case telemetry.AiGenerateSpanData() as d:
             attrs["gen_ai.operation.name"] = "generate_content"
-            provider = _provider_name(d.model, d.provider)
-            if provider is not None:
-                attrs["gen_ai.provider.name"] = provider
+            if d.provider is not None:
+                attrs["gen_ai.provider.name"] = d.provider
             attrs["gen_ai.request.model"] = d.model
-            n = _field(d.params, "n")
+            n = _hack_get_field(d.params, "n")
             if isinstance(n, int) and n != 1:
                 attrs["gen_ai.request.choice.count"] = n
-            seed = _field(d.params, "seed")
+            seed = _hack_get_field(d.params, "seed")
             if isinstance(seed, int):
                 attrs["gen_ai.request.seed"] = seed
             if d.params is not None:
                 # ImageParams vs VideoParams: only the latter has fps.
                 attrs["gen_ai.output.type"] = (
-                    "video" if _has_field(d.params, "fps") else "image"
+                    "video" if _hack_has_field(d.params, "fps") else "image"
                 )
             if d.usage is not None:
-                attrs |= _usage_attributes(d.usage)
+                attrs |= _semconv_usage_attributes(d.usage)
             if capture_content:
-                attrs |= _content_attributes(
+                attrs |= _semconv_content_attributes(
                     d.messages, d.message, error=sp.error is not None
                 )
         case telemetry.ToolExecutionSpanData() as d:
@@ -387,23 +359,22 @@ def _attributes(sp: telemetry.Span, *, capture_content: bool) -> dict[str, Any]:
         case telemetry.RunSpanData() as d:
             attrs["gen_ai.operation.name"] = "invoke_agent"
             attrs["gen_ai.agent.name"] = d.agent
-            provider = _provider_name(d.model, d.provider)
-            if provider is not None:
-                attrs["gen_ai.provider.name"] = provider
+            if d.provider is not None:
+                attrs["gen_ai.provider.name"] = d.provider
             attrs["gen_ai.request.model"] = d.model
             if d.output_type is not None:
                 # Structured output was requested; the semconv value is
                 # the output kind, not the Python type name.
                 attrs["gen_ai.output.type"] = "json"
-            attrs |= _request_attributes(d.params)
+            attrs |= _semconv_request_attributes(d.params)
             if d.usage is not None:
-                attrs |= _usage_attributes(d.usage)
+                attrs |= _semconv_usage_attributes(d.usage)
             if capture_content:
                 if d.tool_names:
-                    attrs["gen_ai.tool.definitions"] = _tool_definitions(
-                        d.tool_names
+                    attrs["gen_ai.tool.definitions"] = (
+                        _semconv_tool_definitions(d.tool_names)
                     )
-                attrs |= _content_attributes(
+                attrs |= _semconv_content_attributes(
                     d.messages, d.final_message, error=sp.error is not None
                 )
         case telemetry.HookSpanData() as d:
@@ -489,8 +460,8 @@ class OtelAdapter(telemetry.Adapter):
         self._provider = provider
         self._live: dict[str, opentelemetry.trace.Span] = {}
 
-        self._capture_content = (
-            _capture_content_from_env()
+        self._is_capturing_content = (
+            _should_capture_content()
             if capture_content is None
             else capture_content
         )
@@ -510,7 +481,7 @@ class OtelAdapter(telemetry.Adapter):
 
     def span_name(self, span_: telemetry.Span, /) -> str:
         """Return the exported otel span name.  Override to customize."""
-        return _name(span_)
+        return _semconv_name(span_)
 
     def span_attributes(self, span_: telemetry.Span, /) -> dict[str, Any]:
         """Return the attributes set at span end.  Override to enrich.
@@ -521,7 +492,7 @@ class OtelAdapter(telemetry.Adapter):
                 def span_attributes(self, span_):
                     return super().span_attributes(span_) | {"k": "v"}
         """
-        return _attributes(span_, capture_content=self._capture_content)
+        return _attributes(span_, capture_content=self._is_capturing_content)
 
     def flush(self) -> None:
         """Flush the provider's exporters."""
@@ -588,7 +559,7 @@ class OtelAdapter(telemetry.Adapter):
             otel_span = self._tracer.start_span(
                 self.span_name(span_),
                 context=parent_context,
-                kind=_kind(span_),
+                kind=_semconv_kind(span_),
                 start_time=span_.started_at,
             )
         finally:
@@ -643,11 +614,8 @@ def install(
 ) -> OtelAdapter:
     """Create the otel adapter, register it, and return it.
 
-    Uses the global tracer provider unless one is passed.  Message
-    content capture is off by default, per the gen_ai conventions;
-    ``capture_content=True`` (or the
-    ``OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT`` environment
-    variable) turns it on.
+    Uses the global tracer provider unless one is passed.
+    Message content capture is opt-in via capture_content or the env var.
     """
     adapter = OtelAdapter(
         tracer_provider=tracer_provider, capture_content=capture_content

--- a/src/ai/experimental_telemetry/span.py
+++ b/src/ai/experimental_telemetry/span.py
@@ -569,14 +569,19 @@ _current_sink: contextvars.ContextVar[Sink | None] = contextvars.ContextVar(
 
 
 @util.contextmanager_any_sync
-def use_sink(sink: Sink) -> Iterator[None]:
+def use_sink(sink: Sink | None) -> Iterator[None]:
     """Route span pushes to ``sink`` within this context.
 
     The default (outside any ``use_sink``) is the adapter registry.
     Inside a durable workflow body where side effects are not allowed, you
     can route to a :class:`Collector` instead and re-push the collected spans
     from a step / activity.
+
+    ``None`` is a no-op.
     """
+    if sink is None:
+        yield
+        return
     token = _current_sink.set(sink)
     try:
         yield

--- a/src/ai/experimental_telemetry/span.py
+++ b/src/ai/experimental_telemetry/span.py
@@ -200,10 +200,11 @@ class SpanData(Protocol):
 class RunSpanData(pydantic.BaseModel):
     """One ``Agent.run``: the whole loop.
 
-    ``blocked``/``final_message`` are set at span end: ``blocked`` is
-    True when the run ended suspended on an unresolved hook (see
-    ``AgentStream.blocked``), ``final_message`` is the last assistant
-    message produced, if any.
+    ``blocked``/``final_message``/``usage`` are set at span end:
+    ``blocked`` is True when the run ended suspended on an unresolved
+    hook (see ``AgentStream.blocked``), ``final_message`` is the last
+    assistant message produced, if any, ``usage`` is the sum of usage
+    across the messages the run produced.
     """
 
     kind: Literal["run"] = "run"
@@ -216,6 +217,7 @@ class RunSpanData(pydantic.BaseModel):
     params: _InferenceParams | None = None
     blocked: bool = False
     final_message: messages_.Message | None = None
+    usage: usage_.Usage | None = None
 
 
 class LoopTurnSpanData(pydantic.BaseModel):
@@ -229,7 +231,7 @@ class LoopTurnSpanData(pydantic.BaseModel):
 
 
 class AiStreamSpanData(pydantic.BaseModel):
-    """One streaming LLM call.  ``message``/``usage`` are set at span end."""
+    """One streaming LLM call."""
 
     kind: Literal["ai_stream"] = "ai_stream"
     model: str
@@ -237,8 +239,12 @@ class AiStreamSpanData(pydantic.BaseModel):
     params: _InferenceParams | None = None
     provider: str | None = None
     tool_names: list[str] | None = None
+    output_type: str | None = None
     message: messages_.Message | None = None
     usage: usage_.Usage | None = None
+    finish_reason: str | None = None
+    response_id: str | None = None
+    response_model: str | None = None
 
 
 class AiGenerateSpanData(pydantic.BaseModel):
@@ -261,11 +267,14 @@ class ToolExecutionSpanData(pydantic.BaseModel):
 
     ``model_input`` is the value the LLM sees on its next turn, set
     only when it differs from ``result`` (aggregator-backed tools).
+    ``tool_description`` is the tool's model-facing description,
+    stamped at dispatch.
     """
 
     kind: Literal["tool_execution"] = "tool_execution"
     tool_name: str
     tool_call_id: str
+    tool_description: str | None = None
     args: dict[str, Any] | None = None
     result: Any = None
     model_input: Any = None

--- a/src/ai/models/core/api.py
+++ b/src/ai/models/core/api.py
@@ -139,6 +139,10 @@ class Stream(Generic[StreamOutputT]):
         # (``Stream(gen)``, ``Stream.replay_message``).
         self._span: telemetry.Span[telemetry.AiStreamSpanData] | None = None
         self._first_output_seen = False
+        # Response identity off the provider's StreamEnd, for telemetry.
+        self._finish_reason: str | None = None
+        self._response_id: str | None = None
+        self._response_model: str | None = None
 
     @classmethod
     def replay_message(
@@ -428,8 +432,16 @@ class Stream(Generic[StreamOutputT]):
                 self._message.parts.append(fp)
                 self._parts[fp.id] = fp
 
-            case types.events.StreamEnd(provider_metadata=pm):
+            case types.events.StreamEnd(
+                provider_metadata=pm,
+                finish_reason=finish,
+                response_id=rid,
+                response_model=rmodel,
+            ):
                 self._ended = True
+                self._finish_reason = finish
+                self._response_id = rid
+                self._response_model = rmodel
                 if pm is not None:
                     self._message.provider_metadata = pm
             case _:
@@ -575,6 +587,7 @@ async def _stream(
         params=params,
         provider=model.provider.name,
         tool_names=[t.name for t in tools] if tools is not None else None,
+        output_type=output_type.__name__ if output_type is not None else None,
     )
     if messages and messages[-1].replay:
         last = messages[-1]
@@ -612,6 +625,9 @@ async def _stream(
             # Record whatever got built, even a partial message.
             sp.data.message = s.message
             sp.data.usage = s.usage
+            sp.data.finish_reason = s._finish_reason
+            sp.data.response_id = s._response_id
+            sp.data.response_model = s._response_model
             await s.aclose()
 
 

--- a/src/ai/providers/ai_gateway/protocol.py
+++ b/src/ai/providers/ai_gateway/protocol.py
@@ -822,6 +822,18 @@ def _expand_tool_call(
     ]
 
 
+# AI SDK finish reasons → the framework's finish reasons (the gen_ai
+# semconv vocabulary, see ``types.events.StreamEnd``); unmapped values
+# (``other``, ``unknown``) pass through raw.
+_FINISH_REASONS: dict[str, str] = {
+    "stop": "stop",
+    "length": "length",
+    "content-filter": "content_filter",
+    "tool-calls": "tool_call",
+    "error": "error",
+}
+
+
 def _parse_usage(data: Any) -> types.usage.Usage:
     """Parse v3 usage data into an internal ``Usage``."""
     if not isinstance(data, dict):
@@ -994,7 +1006,17 @@ def _parse_stream_part(
         case "finish":
             usage_data = data.get("usage")
             usage = _parse_usage(usage_data) if usage_data else None
-            return [types.events.StreamEnd(usage=usage)]
+            finish = data.get("finishReason")
+            return [
+                types.events.StreamEnd(
+                    usage=usage,
+                    finish_reason=(
+                        _FINISH_REASONS.get(finish, finish)
+                        if isinstance(finish, str)
+                        else None
+                    ),
+                )
+            ]
 
         case _:
             return []

--- a/src/ai/providers/ai_gateway/protocol.py
+++ b/src/ai/providers/ai_gateway/protocol.py
@@ -831,6 +831,7 @@ _FINISH_REASONS: dict[str, str] = {
     "content-filter": "content_filter",
     "tool-calls": "tool_call",
     "error": "error",
+    "other": "other",
 }
 
 
@@ -1007,14 +1008,18 @@ def _parse_stream_part(
             usage_data = data.get("usage")
             usage = _parse_usage(usage_data) if usage_data else None
             finish = data.get("finishReason")
+            finish_reason: str | None = None
+            finish_metadata: dict[str, Any] | None = None
+            # "unknown" means the provider didn't report a reason.
+            if isinstance(finish, str) and finish != "unknown":
+                finish_reason = _FINISH_REASONS.get(finish, "other")
+                if finish not in _FINISH_REASONS:
+                    finish_metadata = {"gateway": {"finish_reason": finish}}
             return [
                 types.events.StreamEnd(
                     usage=usage,
-                    finish_reason=(
-                        _FINISH_REASONS.get(finish, finish)
-                        if isinstance(finish, str)
-                        else None
-                    ),
+                    finish_reason=finish_reason,
+                    provider_metadata=finish_metadata,
                 )
             ]
 

--- a/src/ai/providers/anthropic/protocol.py
+++ b/src/ai/providers/anthropic/protocol.py
@@ -900,8 +900,14 @@ async def stream(
             yield events.StreamEnd(
                 usage=usage,
                 finish_reason=(
-                    _FINISH_REASONS.get(stop_reason, stop_reason)
+                    _FINISH_REASONS.get(stop_reason, "other")
                     if stop_reason is not None
+                    else None
+                ),
+                provider_metadata=(
+                    _provider_metadata(stop_reason=stop_reason)
+                    if stop_reason is not None
+                    and stop_reason not in _FINISH_REASONS
                     else None
                 ),
                 response_id=snapshot.id,

--- a/src/ai/providers/anthropic/protocol.py
+++ b/src/ai/providers/anthropic/protocol.py
@@ -41,6 +41,19 @@ _TOOL_RESULT_BLOCK_TYPES: frozenset[str] = frozenset(
 )
 
 
+# Anthropic stop reasons → the framework's finish reasons (the gen_ai
+# semconv vocabulary, see ``types.events.StreamEnd``); values with no
+# semconv equivalent (e.g. ``pause_turn``) pass through raw.
+_FINISH_REASONS: dict[str, str] = {
+    "end_turn": "stop",
+    "stop_sequence": "stop",
+    "max_tokens": "length",
+    "model_context_window_exceeded": "length",
+    "tool_use": "tool_call",
+    "refusal": "content_filter",
+}
+
+
 def _provider_metadata(**values: Any) -> dict[str, Any]:
     """Namespace metadata as ``{"anthropic": {...}}``."""
     return {PROVIDER_NAME: {**values}}
@@ -868,6 +881,7 @@ async def stream(
                             )
 
             snapshot = sdk_stream.current_message_snapshot
+            stop_reason = snapshot.stop_reason
             sdk_usage = snapshot.usage
             cache_read = getattr(sdk_usage, "cache_read_input_tokens", None)
             usage = types.usage.Usage(
@@ -883,7 +897,16 @@ async def stream(
                 ),
                 raw=sdk_usage.model_dump(exclude_none=True) or None,
             )
-            yield events.StreamEnd(usage=usage)
+            yield events.StreamEnd(
+                usage=usage,
+                finish_reason=(
+                    _FINISH_REASONS.get(stop_reason, stop_reason)
+                    if stop_reason is not None
+                    else None
+                ),
+                response_id=snapshot.id,
+                response_model=snapshot.model,
+            )
     except anthropic_sdk.AnthropicError as exc:
         raise errors.map_error(
             exc,

--- a/src/ai/providers/openai/protocol.py
+++ b/src/ai/providers/openai/protocol.py
@@ -22,6 +22,17 @@ if TYPE_CHECKING:
     import openai
     import pydantic
 
+# OpenAI finish reasons → the framework's finish reasons (the gen_ai
+# semconv vocabulary, see ``types.events.StreamEnd``); unmapped values
+# pass through raw.
+_FINISH_REASONS: dict[str, str] = {
+    "stop": "stop",
+    "length": "length",
+    "content_filter": "content_filter",
+    "tool_calls": "tool_call",
+    "function_call": "tool_call",
+}
+
 # ---------------------------------------------------------------------------
 # Message / tool conversion — internal types → OpenAI wire format
 # ---------------------------------------------------------------------------
@@ -591,10 +602,17 @@ async def stream(
         reasoning_started = False
         tc_state: dict[int, dict[str, Any]] = {}
         usage: types.usage.Usage | None = None
+        finish_reason: str | None = None
+        response_id: str | None = None
+        response_model: str | None = None
 
         yield types.events.StreamStart()
 
         async for chunk in sdk_stream:
+            if chunk.id:
+                response_id = chunk.id
+            if chunk.model:
+                response_model = chunk.model
             if chunk.usage is not None:
                 raw = chunk.usage.model_dump(exclude_none=True)
                 reasoning_tokens: int | None = None
@@ -682,6 +700,9 @@ async def stream(
                                 )
 
             if choice.finish_reason is not None:
+                finish_reason = _FINISH_REASONS.get(
+                    choice.finish_reason, choice.finish_reason
+                )
                 if reasoning_started:
                     yield types.events.ReasoningEnd(block_id="reasoning")
                     reasoning_started = False
@@ -696,7 +717,12 @@ async def stream(
                         )
                         tc["started"] = False
 
-        yield types.events.StreamEnd(usage=usage)
+        yield types.events.StreamEnd(
+            usage=usage,
+            finish_reason=finish_reason,
+            response_id=response_id,
+            response_model=response_model,
+        )
     except openai_sdk.OpenAIError as exc:
         raise errors.map_error(
             exc,
@@ -822,6 +848,41 @@ def _provider_metadata_for_response(
         **({"status": status} if isinstance(status, str) else {}),
     }
     return {_OPENAI_METADATA_KEY: data} if data else {}
+
+
+def _finish_reason_from_response(
+    response: Mapping[str, Any] | None,
+) -> str | None:
+    """Derive the framework finish reason from a final Responses payload.
+
+    The Responses API has no finish_reason field: it is derived from
+    the terminal status, the incomplete reason, and whether the output
+    contains function calls.
+    """
+    if response is None:
+        return None
+    match response.get("status"):
+        case "failed":
+            return "error"
+        case "incomplete":
+            details = response.get("incomplete_details")
+            reason = (
+                details.get("reason") if isinstance(details, Mapping) else None
+            )
+            if reason == "max_output_tokens":
+                return "length"
+            return reason if isinstance(reason, str) else None
+        case "completed":
+            output = response.get("output")
+            if isinstance(output, list) and any(
+                isinstance(item, Mapping)
+                and item.get("type") == "function_call"
+                for item in output
+            ):
+                return "tool_call"
+            return "stop"
+        case _:
+            return None
 
 
 def _maybe_item_reference(
@@ -1346,6 +1407,7 @@ async def _stream_responses(
     builtin_states_by_index: dict[str, dict[str, Any]] = {}
     usage: types.usage.Usage | None = None
     response_metadata: dict[str, Any] | None = None
+    final_response: Mapping[str, Any] | None = None
 
     try:
         sdk_stream = await sdk_client.responses.create(**api_kwargs)
@@ -1370,6 +1432,7 @@ async def _stream_responses(
                     response_metadata = _provider_metadata_for_response(
                         response
                     )
+                    final_response = response
                 continue
 
             if event_type == "response.failed":
@@ -1379,6 +1442,7 @@ async def _stream_responses(
                     response_metadata = _provider_metadata_for_response(
                         response
                     )
+                    final_response = response
                 continue
 
             if event_type == "error":
@@ -1786,9 +1850,18 @@ async def _stream_responses(
         for block_id in list(reasoning_blocks):
             yield types.events.ReasoningEnd(block_id=block_id)
 
+        response_id = response_model = None
+        if final_response is not None:
+            rid = final_response.get("id")
+            response_id = rid if isinstance(rid, str) else None
+            rmodel = final_response.get("model")
+            response_model = rmodel if isinstance(rmodel, str) else None
         yield types.events.StreamEnd(
             usage=usage,
             provider_metadata=response_metadata,
+            finish_reason=_finish_reason_from_response(final_response),
+            response_id=response_id,
+            response_model=response_model,
         )
     except openai_sdk.OpenAIError as exc:
         raise errors.map_error(

--- a/src/ai/providers/openai/protocol.py
+++ b/src/ai/providers/openai/protocol.py
@@ -603,6 +603,7 @@ async def stream(
         tc_state: dict[int, dict[str, Any]] = {}
         usage: types.usage.Usage | None = None
         finish_reason: str | None = None
+        raw_finish_reason: str | None = None
         response_id: str | None = None
         response_model: str | None = None
 
@@ -700,8 +701,9 @@ async def stream(
                                 )
 
             if choice.finish_reason is not None:
+                raw_finish_reason = choice.finish_reason
                 finish_reason = _FINISH_REASONS.get(
-                    choice.finish_reason, choice.finish_reason
+                    choice.finish_reason, "other"
                 )
                 if reasoning_started:
                     yield types.events.ReasoningEnd(block_id="reasoning")
@@ -720,14 +722,17 @@ async def stream(
         yield types.events.StreamEnd(
             usage=usage,
             finish_reason=finish_reason,
+            provider_metadata=(
+                {_OPENAI_METADATA_KEY: {"finish_reason": raw_finish_reason}}
+                if finish_reason == "other"
+                else None
+            ),
             response_id=response_id,
             response_model=response_model,
         )
     except openai_sdk.OpenAIError as exc:
         raise errors.map_error(
-            exc,
-            provider=provider,
-            model_id=model.id,
+            exc, provider=provider, model_id=model.id
         ) from exc
 
 
@@ -840,12 +845,21 @@ def _provider_metadata_for_response(
     response_id = response.get("id")
     model = response.get("model")
     status = response.get("status")
+    details = response.get("incomplete_details")
+    incomplete_reason = (
+        details.get("reason") if isinstance(details, Mapping) else None
+    )
     data = {
         **(
             {"response_id": response_id} if isinstance(response_id, str) else {}
         ),
         **({"model": model} if isinstance(model, str) else {}),
         **({"status": status} if isinstance(status, str) else {}),
+        **(
+            {"incomplete_reason": incomplete_reason}
+            if isinstance(incomplete_reason, str)
+            else {}
+        ),
     }
     return {_OPENAI_METADATA_KEY: data} if data else {}
 
@@ -871,7 +885,9 @@ def _finish_reason_from_response(
             )
             if reason == "max_output_tokens":
                 return "length"
-            return reason if isinstance(reason, str) else None
+            if reason == "content_filter":
+                return "content_filter"
+            return "other" if isinstance(reason, str) else None
         case "completed":
             output = response.get("output")
             if isinstance(output, list) and any(

--- a/src/ai/types/events.py
+++ b/src/ai/types/events.py
@@ -52,7 +52,24 @@ class StreamStart(ModelEvent):
 
 
 class StreamEnd(ModelEvent):
+    """End of a model response.
+
+    ``finish_reason`` is why the model stopped.  The framework adopts
+    the OpenTelemetry gen_ai finish-reason vocabulary as its own:
+    ``stop``, ``length``, ``content_filter``, ``tool_call``, ``error``.
+    Provider adapters normalize their native stop reasons into it;
+    provider values with no equivalent pass through verbatim.
+
+    ``response_id``/``response_model`` identify the provider response —
+    ``response_model`` can differ from the requested model under
+    gateway routing or fallbacks.  All are ``None`` when the provider
+    doesn't report them.
+    """
+
     kind: Literal["stream_end"] = "stream_end"
+    finish_reason: str | None = None
+    response_id: str | None = None
+    response_model: str | None = None
 
 
 class TextStart(ModelEvent):

--- a/src/ai/types/events.py
+++ b/src/ai/types/events.py
@@ -56,9 +56,10 @@ class StreamEnd(ModelEvent):
 
     ``finish_reason`` is why the model stopped.  The framework adopts
     the OpenTelemetry gen_ai finish-reason vocabulary as its own:
-    ``stop``, ``length``, ``content_filter``, ``tool_call``, ``error``.
-    Provider adapters normalize their native stop reasons into it;
-    provider values with no equivalent pass through verbatim.
+    ``stop``, ``length``, ``content_filter``, ``tool_call``, ``error``,
+    plus ``other`` as a catch-all.  Provider adapters normalize their
+    native stop reasons into it; a provider value with no equivalent
+    becomes ``other`` with the raw value kept in ``provider_metadata``.
 
     ``response_id``/``response_model`` identify the provider response —
     ``response_model`` can differ from the requested model under

--- a/tests/agents/test_agent.py
+++ b/tests/agents/test_agent.py
@@ -2,11 +2,29 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING, Any
+
 import pytest
 
 import ai
+from ai.types import events as events_
+from ai.types import usage as usage_
 
-from ..conftest import MOCK_MODEL, Recorder, mock_llm, text_msg, tool_call_msg
+from ..conftest import (
+    MOCK_MODEL,
+    MOCK_PROVIDER,
+    Recorder,
+    emit_events_for_messages,
+    mock_llm,
+    text_msg,
+    tool_call_msg,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
+    from ai import models
+    from ai.types import messages as messages_
 
 
 def _by_name(
@@ -68,6 +86,7 @@ async def test_agent_run_span_tree(recorder: Recorder) -> None:
         tool_span.data, ai.experimental_telemetry.ToolExecutionSpanData
     )
     assert tool_span.data.tool_name == "lookup"
+    assert tool_span.data.tool_description == "Tool that opens a user span."
     assert tool_span.data.args == {"x": 1}
     assert tool_span.data.result == "ok"
     assert not tool_span.data.is_error
@@ -78,6 +97,47 @@ async def test_agent_run_span_tree(recorder: Recorder) -> None:
     assert isinstance(calls[1].data, ai.experimental_telemetry.AiStreamSpanData)
     assert calls[1].data.message is not None
     assert calls[1].data.message.text == "done"
+
+
+async def test_run_span_aggregates_usage(recorder: Recorder) -> None:
+    """The run span sums usage across the run's model calls."""
+    responses = [
+        (
+            [tool_call_msg(name="lookup", args='{"x": 1}')],
+            usage_.Usage(input_tokens=10, output_tokens=2),
+        ),
+        (
+            [text_msg("done")],
+            usage_.Usage(input_tokens=20, output_tokens=3),
+        ),
+    ]
+
+    async def _stream_impl(
+        model: models.Model,
+        messages: list[messages_.Message],
+        **kwargs: Any,
+    ) -> AsyncGenerator[events_.Event]:
+        seq, usage = responses.pop(0)
+        async for event in emit_events_for_messages(seq, usage=usage):
+            yield event
+
+    MOCK_PROVIDER._stream_impl = _stream_impl
+
+    @ai.tool
+    async def lookup(x: int) -> str:
+        """Look up a number."""
+        return "ok"
+
+    my_agent = ai.Agent(tools=[lookup])
+    async with my_agent.run(MOCK_MODEL, [ai.user_message("go")]) as stream:
+        async for _ in stream:
+            pass
+
+    (run,) = _by_name(recorder)["run"]
+    assert isinstance(run.data, ai.experimental_telemetry.RunSpanData)
+    assert run.data.usage is not None
+    assert run.data.usage.input_tokens == 30
+    assert run.data.usage.output_tokens == 5
 
 
 async def test_early_break_closes_span_tree(recorder: Recorder) -> None:

--- a/tests/experimental_telemetry/test_otel.py
+++ b/tests/experimental_telemetry/test_otel.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from typing import TYPE_CHECKING, Any
 
 import pytest
@@ -10,9 +11,13 @@ from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
     InMemorySpanExporter,
 )
+from opentelemetry.trace import SpanKind
 
 import ai
 from ai.experimental_telemetry import otel
+from ai.models.core import params as core_params
+from ai.types import messages as messages_
+from ai.types import usage as usage_
 
 from ..conftest import MOCK_MODEL, mock_llm, text_msg, tool_call_msg
 
@@ -25,7 +30,7 @@ def otel_env() -> Iterator[tuple[InMemorySpanExporter, TracerProvider]]:
     exporter = InMemorySpanExporter()
     provider = TracerProvider()
     provider.add_span_processor(SimpleSpanProcessor(exporter))
-    adapter = otel.install(tracer_provider=provider)
+    adapter = otel.install(tracer_provider=provider, capture_content=True)
     yield exporter, provider
     ai.experimental_telemetry.unregister(adapter)
 
@@ -57,10 +62,27 @@ async def test_model_call_attributes(
 
     (span,) = exporter.get_finished_spans()
     assert span.name == "chat mock-model"
-    assert span.attributes is not None
-    assert span.attributes["gen_ai.operation.name"] == "chat"
-    assert span.attributes["gen_ai.request.model"] == "mock-model"
-    assert "hello" in str(span.attributes["gen_ai.output.messages"])
+    # Inference spans are CLIENT per semconv.
+    assert span.kind is SpanKind.CLIENT
+    attrs = span.attributes
+    assert attrs is not None
+    assert attrs["gen_ai.operation.name"] == "chat"
+    assert attrs["gen_ai.provider.name"] == "mock"
+    assert attrs["gen_ai.request.model"] == "mock-model"
+    assert attrs["gen_ai.request.stream"] is True
+    ttfc = attrs["gen_ai.response.time_to_first_chunk"]
+    assert isinstance(ttfc, float) and ttfc >= 0
+    # Content in the semconv message shape, not our native model dump.
+    assert json.loads(str(attrs["gen_ai.input.messages"])) == [
+        {"role": "user", "parts": [{"type": "text", "content": "hi"}]}
+    ]
+    assert json.loads(str(attrs["gen_ai.output.messages"])) == [
+        {
+            "role": "assistant",
+            "parts": [{"type": "text", "content": "hello"}],
+            "finish_reason": "stop",
+        }
+    ]
 
 
 async def test_error_status(
@@ -101,9 +123,13 @@ async def test_tool_exception_recorded(
         if s.name == "execute_tool boom"
     ]
     # The tool exception is caught by the framework, but the span still
-    # records it: ERROR status carrying the failure's type and message.
+    # records it: ERROR status carrying the failure's type and message,
+    # plus the semconv ``error.type`` attribute.
     assert not span.status.is_ok
     assert span.status.description == "ValueError: nope"
+    assert span.attributes is not None
+    assert span.attributes["error.type"] == "ValueError"
+    assert span.attributes["gen_ai.tool.type"] == "function"
 
 
 async def test_span_events_exported_with_original_timestamps(
@@ -299,3 +325,269 @@ async def test_subclass_can_enrich_names_and_attributes() -> None:
     assert span.attributes is not None
     assert span.attributes["foo"] == "bar"
     assert span.attributes["extra"] is True
+
+
+async def test_content_capture_off_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(otel.CAPTURE_CONTENT_ENV, raising=False)
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    adapter = otel.install(tracer_provider=provider)
+    try:
+        mock_llm([[text_msg("hello")]])
+        async with ai.stream(MOCK_MODEL, [ai.user_message("hi")]) as stream:
+            async for _ in stream:
+                pass
+    finally:
+        ai.experimental_telemetry.unregister(adapter)
+
+    (span,) = exporter.get_finished_spans()
+    attrs = span.attributes
+    assert attrs is not None
+    # Telemetry attributes still export; content is Opt-In per semconv.
+    assert attrs["gen_ai.request.model"] == "mock-model"
+    assert "gen_ai.input.messages" not in attrs
+    assert "gen_ai.output.messages" not in attrs
+    assert "gen_ai.system_instructions" not in attrs
+    assert "gen_ai.tool.definitions" not in attrs
+
+
+async def test_content_capture_env_opt_in(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(otel.CAPTURE_CONTENT_ENV, "span_only")
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    adapter = otel.install(tracer_provider=provider)
+    try:
+        mock_llm([[text_msg("hello")]])
+        async with ai.stream(MOCK_MODEL, [ai.user_message("hi")]) as stream:
+            async for _ in stream:
+                pass
+    finally:
+        ai.experimental_telemetry.unregister(adapter)
+
+    (span,) = exporter.get_finished_spans()
+    assert span.attributes is not None
+    assert "gen_ai.input.messages" in span.attributes
+
+
+def _stream_span(
+    **data_kwargs: Any,
+) -> ai.experimental_telemetry.Span[Any]:
+    data_kwargs.setdefault("messages", [ai.user_message("hi")])
+    data = ai.experimental_telemetry.AiStreamSpanData(
+        model="mock-model", **data_kwargs
+    )
+    return ai.experimental_telemetry.Span(
+        name="ai_stream", data=data, id="span-1", trace_id="trace-1"
+    )
+
+
+def test_request_and_usage_attributes() -> None:
+    params = core_params.InferenceRequestParams(
+        sampling={
+            core_params.TemperatureSamplerParams: (
+                core_params.TemperatureSamplerParams(temperature=0.5)
+            ),
+            core_params.TopPSamplerParams: (
+                core_params.TopPSamplerParams(top_p=0.9)
+            ),
+            # Left at the provider-default sentinel: must not export.
+            core_params.TopKSamplerParams: core_params.TopKSamplerParams(),
+        },
+        reasoning=core_params.ReasoningParams(effort="high"),
+        output=core_params.OutputParams(max_tokens=128),
+    )
+    usage = usage_.Usage(
+        input_tokens=10,
+        output_tokens=5,
+        reasoning_tokens=2,
+        cache_read_tokens=3,
+        cache_write_tokens=4,
+    )
+    sp = _stream_span(params=params, usage=usage, provider="mock")
+
+    attrs = otel._attributes(sp, capture_content=False)
+    assert attrs["gen_ai.provider.name"] == "mock"
+    assert attrs["gen_ai.request.temperature"] == 0.5
+    assert attrs["gen_ai.request.top_p"] == 0.9
+    assert "gen_ai.request.top_k" not in attrs
+    assert attrs["gen_ai.request.max_tokens"] == 128
+    assert attrs["gen_ai.request.reasoning.level"] == "high"
+    assert attrs["gen_ai.usage.input_tokens"] == 10
+    assert attrs["gen_ai.usage.output_tokens"] == 5
+    assert attrs["gen_ai.usage.reasoning.output_tokens"] == 2
+    assert attrs["gen_ai.usage.cache_read.input_tokens"] == 3
+    assert attrs["gen_ai.usage.cache_creation.input_tokens"] == 4
+    assert "gen_ai.input.messages" not in attrs
+
+
+def test_request_attributes_from_json_restored_params() -> None:
+    # A span restored from JSON carries params as plain dicts.
+    sp = _stream_span(
+        params={
+            "sampling": {"temperature": {"temperature": 0.25}},
+            "output": {"max_tokens": 64},
+            "reasoning": {"effort": "low"},
+        }
+    )
+    attrs = otel._attributes(sp, capture_content=False)
+    assert attrs["gen_ai.request.temperature"] == 0.25
+    assert attrs["gen_ai.request.max_tokens"] == 64
+    assert attrs["gen_ai.request.reasoning.level"] == "low"
+
+
+def test_semconv_message_content_shapes() -> None:
+    messages = [
+        messages_.Message(
+            role="system", parts=[messages_.TextPart(text="be nice")]
+        ),
+        messages_.Message(
+            role="user",
+            parts=[
+                messages_.TextPart(text="hi"),
+                messages_.FilePart(
+                    data="https://e.com/a.png", media_type="image/png"
+                ),
+                messages_.FilePart(data="QUJD", media_type="application/pdf"),
+            ],
+        ),
+        messages_.Message(
+            role="assistant",
+            parts=[
+                messages_.ReasoningPart(text="hmm"),
+                messages_.BuiltinToolCallPart(
+                    tool_call_id="b1",
+                    tool_name="web_search",
+                    tool_args='{"q": "x"}',
+                ),
+                messages_.BuiltinToolReturnPart(
+                    tool_call_id="b1",
+                    tool_name="web_search",
+                    result={"hits": 1},
+                ),
+            ],
+        ),
+        messages_.Message(
+            role="tool",
+            parts=[
+                messages_.ToolResultPart(
+                    tool_call_id="t1", tool_name="lookup", result={"ok": True}
+                )
+            ],
+        ),
+    ]
+    sp = _stream_span(messages=messages, message=tool_call_msg(name="lookup"))
+
+    attrs = otel._attributes(sp, capture_content=True)
+    # System messages move out of input.messages, as a flat parts list.
+    assert json.loads(attrs["gen_ai.system_instructions"]) == [
+        {"type": "text", "content": "be nice"}
+    ]
+    inputs = json.loads(attrs["gen_ai.input.messages"])
+    assert [m["role"] for m in inputs] == ["user", "assistant", "tool"]
+    assert inputs[0]["parts"] == [
+        {"type": "text", "content": "hi"},
+        {
+            "type": "uri",
+            "modality": "image",
+            "mime_type": "image/png",
+            "uri": "https://e.com/a.png",
+        },
+        {
+            "type": "blob",
+            "modality": "document",
+            "mime_type": "application/pdf",
+            "content": "QUJD",
+        },
+    ]
+    assert inputs[1]["parts"] == [
+        {"type": "reasoning", "content": "hmm"},
+        {
+            "type": "server_tool_call",
+            "id": "b1",
+            "name": "web_search",
+            "server_tool_call": {
+                "type": "web_search",
+                "arguments": {"q": "x"},
+            },
+        },
+        {
+            "type": "server_tool_call_response",
+            "id": "b1",
+            "server_tool_call_response": {
+                "type": "web_search",
+                "response": {"hits": 1},
+            },
+        },
+    ]
+    assert inputs[2]["parts"] == [
+        {"type": "tool_call_response", "id": "t1", "response": {"ok": True}}
+    ]
+    (out,) = json.loads(attrs["gen_ai.output.messages"])
+    assert out["finish_reason"] == "tool_call"
+    assert out["parts"] == [
+        {"type": "tool_call", "id": "tc-1", "name": "lookup", "arguments": {}}
+    ]
+
+
+def test_generate_span_attributes() -> None:
+    data = ai.experimental_telemetry.AiGenerateSpanData(
+        model="mock-model",
+        messages=[ai.user_message("draw")],
+        params=core_params.ImageParams(n=2, seed=7),
+        provider="mock",
+    )
+    sp = ai.experimental_telemetry.Span(
+        name="ai_generate", data=data, id="span-1", trace_id="trace-1"
+    )
+    attrs = otel._attributes(sp, capture_content=False)
+    assert attrs["gen_ai.operation.name"] == "generate_content"
+    assert attrs["gen_ai.provider.name"] == "mock"
+    assert attrs["gen_ai.request.choice.count"] == 2
+    assert attrs["gen_ai.request.seed"] == 7
+    assert attrs["gen_ai.output.type"] == "image"
+
+    data = ai.experimental_telemetry.AiGenerateSpanData(
+        model="mock-model",
+        messages=[ai.user_message("film")],
+        params=core_params.VideoParams(),
+        provider="mock",
+    )
+    sp = ai.experimental_telemetry.Span(
+        name="ai_generate", data=data, id="span-2", trace_id="trace-1"
+    )
+    attrs = otel._attributes(sp, capture_content=False)
+    assert attrs["gen_ai.output.type"] == "video"
+    assert "gen_ai.request.choice.count" not in attrs
+
+
+def test_run_span_attributes() -> None:
+    data = ai.experimental_telemetry.RunSpanData(
+        agent="MyAgent",
+        model="anthropic/claude-x",
+        messages=[ai.user_message("hi")],
+        provider="ai-gateway",
+        tool_names=["lookup"],
+        output_type="MyModel",
+    )
+    sp = ai.experimental_telemetry.Span(
+        name="run", data=data, id="span-1", trace_id="trace-1"
+    )
+    attrs = otel._attributes(sp, capture_content=True)
+    assert attrs["gen_ai.operation.name"] == "invoke_agent"
+    assert attrs["gen_ai.agent.name"] == "MyAgent"
+    # Gateway model ids carry the actual provider as their prefix.
+    assert attrs["gen_ai.provider.name"] == "anthropic"
+    assert attrs["gen_ai.request.model"] == "anthropic/claude-x"
+    # Structured output requested: the semconv output kind, not the
+    # Python type name.
+    assert attrs["gen_ai.output.type"] == "json"
+    assert json.loads(attrs["gen_ai.tool.definitions"]) == [
+        {"type": "function", "name": "lookup"}
+    ]
+    assert "gen_ai.input.messages" in attrs

--- a/tests/experimental_telemetry/test_otel.py
+++ b/tests/experimental_telemetry/test_otel.py
@@ -615,8 +615,7 @@ def test_run_span_attributes() -> None:
     attrs = otel._attributes(sp, capture_content=True)
     assert attrs["gen_ai.operation.name"] == "invoke_agent"
     assert attrs["gen_ai.agent.name"] == "MyAgent"
-    # Gateway model ids carry the actual provider as their prefix.
-    assert attrs["gen_ai.provider.name"] == "anthropic"
+    assert attrs["gen_ai.provider.name"] == "ai-gateway"
     assert attrs["gen_ai.request.model"] == "anthropic/claude-x"
     # Structured output requested: the semconv output kind, not the
     # Python type name.

--- a/tests/experimental_telemetry/test_otel.py
+++ b/tests/experimental_telemetry/test_otel.py
@@ -441,6 +441,39 @@ def test_request_attributes_from_json_restored_params() -> None:
     assert attrs["gen_ai.request.reasoning.level"] == "low"
 
 
+def test_response_identity_attributes() -> None:
+    sp = _stream_span(
+        output_type="MyModel",
+        message=text_msg("truncated"),
+        finish_reason="length",
+        response_id="resp-1",
+        response_model="mock-model-v2",
+    )
+    attrs = otel._attributes(sp, capture_content=True)
+    assert attrs["gen_ai.response.finish_reasons"] == ["length"]
+    assert attrs["gen_ai.response.id"] == "resp-1"
+    assert attrs["gen_ai.response.model"] == "mock-model-v2"
+    # Structured output requested: the semconv output kind, not the
+    # Python type name.
+    assert attrs["gen_ai.output.type"] == "json"
+    # The captured finish reason wins over the inferred fallback.
+    (out,) = json.loads(attrs["gen_ai.output.messages"])
+    assert out["finish_reason"] == "length"
+
+
+def test_tool_span_description() -> None:
+    data = ai.experimental_telemetry.ToolExecutionSpanData(
+        tool_name="lookup",
+        tool_call_id="tc-1",
+        tool_description="Look things up.",
+    )
+    sp = ai.experimental_telemetry.Span(
+        name="tool_execution", data=data, id="span-1", trace_id="trace-1"
+    )
+    attrs = otel._attributes(sp, capture_content=False)
+    assert attrs["gen_ai.tool.description"] == "Look things up."
+
+
 def test_semconv_message_content_shapes() -> None:
     messages = [
         messages_.Message(
@@ -574,6 +607,7 @@ def test_run_span_attributes() -> None:
         provider="ai-gateway",
         tool_names=["lookup"],
         output_type="MyModel",
+        usage=usage_.Usage(input_tokens=30, output_tokens=5),
     )
     sp = ai.experimental_telemetry.Span(
         name="run", data=data, id="span-1", trace_id="trace-1"
@@ -587,6 +621,8 @@ def test_run_span_attributes() -> None:
     # Structured output requested: the semconv output kind, not the
     # Python type name.
     assert attrs["gen_ai.output.type"] == "json"
+    assert attrs["gen_ai.usage.input_tokens"] == 30
+    assert attrs["gen_ai.usage.output_tokens"] == 5
     assert json.loads(attrs["gen_ai.tool.definitions"]) == [
         {"type": "function", "name": "lookup"}
     ]

--- a/tests/experimental_telemetry/test_telemetry.py
+++ b/tests/experimental_telemetry/test_telemetry.py
@@ -458,6 +458,25 @@ async def test_use_sink_reroutes_pushes(recorder: Recorder) -> None:
     assert [s.name for s in recorder.ended] == ["outside"]
 
 
+async def test_use_sink_accepts_none(recorder: Recorder) -> None:
+    with ai.experimental_telemetry.use_sink(None):
+        async with ai.experimental_telemetry.span("inside"):
+            pass
+    assert [s.name for s in recorder.ended] == ["inside"]
+
+
+async def test_use_sink_none_preserves_outer_sink(recorder: Recorder) -> None:
+    collector = ai.experimental_telemetry.Collector()
+    with (
+        ai.experimental_telemetry.use_sink(collector),
+        ai.experimental_telemetry.use_sink(None),
+    ):
+        async with ai.experimental_telemetry.span("inside"):
+            pass
+    assert [s.name for s in collector.finished] == ["inside"]
+    assert recorder.ended == []
+
+
 async def test_collector_ships_to_adapters_exactly_as_pushed(
     recorder: Recorder,
 ) -> None:

--- a/tests/models/core/test_api.py
+++ b/tests/models/core/test_api.py
@@ -696,6 +696,43 @@ async def test_early_close_no_response_complete(recorder: Recorder) -> None:
     ]
 
 
+async def test_stream_span_captures_response_identity(
+    recorder: Recorder,
+) -> None:
+    """StreamEnd's finish reason and response identity land on span data."""
+
+    async def _identified_stream(
+        model: models.Model,
+        messages: list[messages_.Message],
+        **kwargs: Any,
+    ) -> AsyncGenerator[events_.Event]:
+        yield events_.StreamStart()
+        yield events_.TextDelta(block_id="t", chunk="hi")
+        yield events_.StreamEnd(
+            finish_reason="length",
+            response_id="resp-1",
+            response_model="mock-model-v2",
+        )
+
+    MOCK_PROVIDER._stream_impl = _identified_stream
+
+    class Out(pydantic.BaseModel):
+        x: int
+
+    async with models.stream(
+        MOCK_MODEL, [ai.user_message("Hi")], output_type=Out
+    ) as stream:
+        async for _ in stream:
+            pass
+
+    (call,) = [s for s in recorder.ended if s.name == "ai_stream"]
+    assert isinstance(call.data, ai.experimental_telemetry.AiStreamSpanData)
+    assert call.data.output_type == "Out"
+    assert call.data.finish_reason == "length"
+    assert call.data.response_id == "resp-1"
+    assert call.data.response_model == "mock-model-v2"
+
+
 async def test_directly_constructed_stream_has_no_span() -> None:
     async with ai.Stream.replay_message(text_msg("hi")) as stream:
         async for _ in stream:

--- a/tests/providers/ai_gateway/test_stream.py
+++ b/tests/providers/ai_gateway/test_stream.py
@@ -90,6 +90,26 @@ class TestStreaming:
         assert final.usage.input_tokens == 5
         assert final.usage.output_tokens == 2
 
+    async def test_finish_reason_normalized_on_stream_end(self) -> None:
+        body = sse(
+            {"type": "text-start", "id": "t1"},
+            {"type": "text-delta", "id": "t1", "textDelta": "x"},
+            {"type": "text-end", "id": "t1"},
+            {"type": "finish", "finishReason": "tool-calls", "usage": {}},
+        )
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, text=body)
+
+        collected = await _collect(
+            mock_client(httpx.MockTransport(handler)), [user_msg("Hi")]
+        )
+        end = collected[-1]
+        assert isinstance(end, events.StreamEnd)
+        # AI SDK values are normalized to the framework's finish-reason
+        # vocabulary (the gen_ai semconv one, see StreamEnd).
+        assert end.finish_reason == "tool_call"
+
     async def test_reasoning_then_text(self) -> None:
         body = sse(
             {"type": "reasoning-start", "id": "r1"},

--- a/tests/providers/ai_gateway/test_stream.py
+++ b/tests/providers/ai_gateway/test_stream.py
@@ -110,6 +110,51 @@ class TestStreaming:
         # vocabulary (the gen_ai semconv one, see StreamEnd).
         assert end.finish_reason == "tool_call"
 
+    async def test_unmapped_finish_reason_becomes_other(self) -> None:
+        body = sse(
+            {"type": "text-start", "id": "t1"},
+            {"type": "text-delta", "id": "t1", "textDelta": "x"},
+            {"type": "text-end", "id": "t1"},
+            {
+                "type": "finish",
+                "finishReason": "brand-new-reason",
+                "usage": {},
+            },
+        )
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, text=body)
+
+        collected = await _collect(
+            mock_client(httpx.MockTransport(handler)), [user_msg("Hi")]
+        )
+        end = collected[-1]
+        assert isinstance(end, events.StreamEnd)
+        assert end.finish_reason == "other"
+        assert end.provider_metadata == {
+            "gateway": {"finish_reason": "brand-new-reason"}
+        }
+
+    async def test_unknown_finish_reason_becomes_none(self) -> None:
+        body = sse(
+            {"type": "text-start", "id": "t1"},
+            {"type": "text-delta", "id": "t1", "textDelta": "x"},
+            {"type": "text-end", "id": "t1"},
+            {"type": "finish", "finishReason": "unknown", "usage": {}},
+        )
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, text=body)
+
+        collected = await _collect(
+            mock_client(httpx.MockTransport(handler)), [user_msg("Hi")]
+        )
+        end = collected[-1]
+        assert isinstance(end, events.StreamEnd)
+        # "unknown" means the provider didn't report a reason.
+        assert end.finish_reason is None
+        assert end.provider_metadata is None
+
     async def test_reasoning_then_text(self) -> None:
         body = sse(
             {"type": "reasoning-start", "id": "r1"},

--- a/tests/providers/anthropic/conftest.py
+++ b/tests/providers/anthropic/conftest.py
@@ -39,9 +39,19 @@ class FakeUsage:
 class FakeSnapshot:
     """Mimics ``MessageStream.current_message_snapshot``."""
 
-    def __init__(self, content: list[Any] | None = None) -> None:
+    def __init__(
+        self,
+        content: list[Any] | None = None,
+        *,
+        stop_reason: str | None = None,
+        id: str = "msg_test",
+        model: str = "claude-test",
+    ) -> None:
         self.usage = FakeUsage()
         self.content = content or []
+        self.stop_reason = stop_reason
+        self.id = id
+        self.model = model
 
 
 class FakeStream:
@@ -55,9 +65,13 @@ class FakeStream:
         self,
         events: Iterable[Any] = (),
         snapshot_content: list[Any] | None = None,
+        *,
+        stop_reason: str | None = None,
     ) -> None:
         self._events = list(events)
-        self.current_message_snapshot = FakeSnapshot(snapshot_content)
+        self.current_message_snapshot = FakeSnapshot(
+            snapshot_content, stop_reason=stop_reason
+        )
 
     async def __aenter__(self) -> FakeStream:
         return self

--- a/tests/providers/anthropic/test_stream.py
+++ b/tests/providers/anthropic/test_stream.py
@@ -157,7 +157,7 @@ async def test_event_kinds_in_order(monkeypatch: pytest.MonkeyPatch) -> None:
         ("max_tokens", "length"),
         ("tool_use", "tool_call"),
         ("refusal", "content_filter"),
-        ("pause_turn", "pause_turn"),  # no framework equivalent: verbatim
+        ("pause_turn", "other"),  # no framework equivalent
     ],
 )
 async def test_stream_end_carries_response_identity(
@@ -192,6 +192,12 @@ async def test_stream_end_carries_response_identity(
     end = collected[-1]
     assert isinstance(end, events.StreamEnd)
     assert end.finish_reason == finish_reason
+    if finish_reason == "other":
+        assert end.provider_metadata == {
+            "anthropic": {"stop_reason": stop_reason}
+        }
+    else:
+        assert end.provider_metadata is None
     assert end.response_id == "msg_test"
     assert end.response_model == "claude-test"
 

--- a/tests/providers/anthropic/test_stream.py
+++ b/tests/providers/anthropic/test_stream.py
@@ -150,6 +150,52 @@ async def test_event_kinds_in_order(monkeypatch: pytest.MonkeyPatch) -> None:
     ]
 
 
+@pytest.mark.parametrize(
+    ("stop_reason", "finish_reason"),
+    [
+        ("end_turn", "stop"),
+        ("max_tokens", "length"),
+        ("tool_use", "tool_call"),
+        ("refusal", "content_filter"),
+        ("pause_turn", "pause_turn"),  # no framework equivalent: verbatim
+    ],
+)
+async def test_stream_end_carries_response_identity(
+    monkeypatch: pytest.MonkeyPatch,
+    stop_reason: str,
+    finish_reason: str,
+) -> None:
+    """The snapshot's stop reason / id / model land on ``StreamEnd``.
+
+    The stop reason is normalized to the framework's finish-reason
+    vocabulary (the gen_ai semconv one, see ``StreamEnd``).
+    """
+    sdk_events = [
+        block_start(0, "text"),
+        block_delta(0, "text_delta", text="hi"),
+        block_stop(0),
+    ]
+    fake = FakeAnthropicClient(
+        stream=FakeStream(sdk_events, stop_reason=stop_reason)
+    )
+    _ = monkeypatch
+
+    collected = [
+        event
+        async for event in protocol.stream(
+            cast("anthropic.AsyncAnthropic", fake),
+            _MODEL,
+            [ai.user_message("Hi")],
+            provider="anthropic",
+        )
+    ]
+    end = collected[-1]
+    assert isinstance(end, events.StreamEnd)
+    assert end.finish_reason == finish_reason
+    assert end.response_id == "msg_test"
+    assert end.response_model == "claude-test"
+
+
 async def test_builtin_tool_end_carries_call_part(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/providers/openai/test_adapter.py
+++ b/tests/providers/openai/test_adapter.py
@@ -355,6 +355,70 @@ async def test_responses_streams_text_and_usage() -> None:
     }
 
 
+@pytest.mark.parametrize(
+    ("response", "finish_reason"),
+    [
+        (
+            {"id": "resp_1", "model": "gpt-5.4-turbo", "status": "completed"},
+            "stop",
+        ),
+        (
+            {
+                "id": "resp_1",
+                "model": "gpt-5.4-turbo",
+                "status": "completed",
+                "output": [{"type": "function_call", "name": "lookup"}],
+            },
+            "tool_call",
+        ),
+        (
+            {
+                "id": "resp_1",
+                "model": "gpt-5.4-turbo",
+                "status": "incomplete",
+                "incomplete_details": {"reason": "max_output_tokens"},
+            },
+            "length",
+        ),
+        (
+            {
+                "id": "resp_1",
+                "model": "gpt-5.4-turbo",
+                "status": "incomplete",
+                "incomplete_details": {"reason": "content_filter"},
+            },
+            "content_filter",
+        ),
+        (
+            {"id": "resp_1", "model": "gpt-5.4-turbo", "status": "failed"},
+            "error",
+        ),
+    ],
+)
+async def test_responses_stream_end_response_identity(
+    response: dict[str, Any], finish_reason: str
+) -> None:
+    """The final response's identity and finish reason land on StreamEnd."""
+    fake, _ = _patch_responses(
+        [{"type": f"response.{response['status']}", "response": response}]
+    )
+
+    collected = [
+        event
+        async for event in protocol.OpenAIResponsesProtocol().stream(
+            fake,
+            _MODEL,
+            [ai.user_message("Hi")],
+            provider="openai",
+        )
+    ]
+    end = collected[-1]
+    assert isinstance(end, events.StreamEnd)
+    assert end.finish_reason == finish_reason
+    assert end.response_id == "resp_1"
+    assert end.response_model == "gpt-5.4-turbo"
+
+
 async def test_responses_streams_function_tool_call() -> None:
     fake, _ = _patch_responses(
         [

--- a/tests/providers/openai/test_adapter.py
+++ b/tests/providers/openai/test_adapter.py
@@ -6,6 +6,7 @@ formatting, and explicit guards against unsupported built-in tool surfaces.
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from typing import Any, cast
 
 import httpx
@@ -32,14 +33,14 @@ class _EmptyOpenAIStream:
 
 
 class _ListStream:
-    def __init__(self, items: list[dict[str, Any]]) -> None:
+    def __init__(self, items: list[Any]) -> None:
         self._items = items
         self._idx = 0
 
     def __aiter__(self) -> _ListStream:
         return self
 
-    async def __anext__(self) -> dict[str, Any]:
+    async def __anext__(self) -> Any:
         if self._idx >= len(self._items):
             raise StopAsyncIteration
         item = self._items[self._idx]
@@ -56,9 +57,23 @@ class _FakeCompletions:
         return _EmptyOpenAIStream()
 
 
+class _ChunkCompletions:
+    """Fake completions endpoint replaying prebuilt stream chunks."""
+
+    def __init__(self, captured: dict[str, Any], chunks: list[Any]) -> None:
+        self._captured = captured
+        self._chunks = chunks
+
+    async def create(self, **kwargs: Any) -> _ListStream:
+        self._captured.update(kwargs)
+        return _ListStream(self._chunks)
+
+
 class _FakeChat:
     def __init__(self, captured: dict[str, Any]) -> None:
-        self.completions = _FakeCompletions(captured)
+        self.completions: _FakeCompletions | _ChunkCompletions = (
+            _FakeCompletions(captured)
+        )
 
 
 class _FakeOpenAIClient:
@@ -393,6 +408,15 @@ async def test_responses_streams_text_and_usage() -> None:
             {"id": "resp_1", "model": "gpt-5.4-turbo", "status": "failed"},
             "error",
         ),
+        (
+            {
+                "id": "resp_1",
+                "model": "gpt-5.4-turbo",
+                "status": "incomplete",
+                "incomplete_details": {"reason": "brand_new_reason"},
+            },
+            "other",
+        ),
     ],
 )
 async def test_responses_stream_end_response_identity(
@@ -417,6 +441,59 @@ async def test_responses_stream_end_response_identity(
     assert end.finish_reason == finish_reason
     assert end.response_id == "resp_1"
     assert end.response_model == "gpt-5.4-turbo"
+    if finish_reason == "other":
+        # the raw provider reason is preserved in provider_metadata
+        assert end.provider_metadata is not None
+        openai_metadata = end.provider_metadata["openai"]
+        assert openai_metadata["incomplete_reason"] == "brand_new_reason"
+
+
+@pytest.mark.parametrize(
+    ("raw_finish_reason", "finish_reason"),
+    [
+        ("stop", "stop"),
+        ("tool_calls", "tool_call"),
+        ("brand_new_reason", "other"),  # no framework equivalent
+    ],
+)
+async def test_chat_stream_end_finish_reason(
+    raw_finish_reason: str, finish_reason: str
+) -> None:
+    """Chat finish reasons normalize; unmapped ones become ``other``
+    with the raw value preserved in ``provider_metadata``."""
+    chunk = SimpleNamespace(
+        id="chatcmpl-1",
+        model="gpt-5.4",
+        usage=None,
+        choices=[
+            SimpleNamespace(
+                delta=SimpleNamespace(content="Hi", tool_calls=None),
+                finish_reason=raw_finish_reason,
+            )
+        ],
+    )
+    captured: dict[str, Any] = {}
+    fake = _FakeOpenAIClient(captured)
+    fake.chat.completions = _ChunkCompletions(captured, [chunk])
+
+    collected = [
+        event
+        async for event in protocol.stream(
+            cast("openai.AsyncOpenAI", fake),
+            _MODEL,
+            [ai.user_message("Hi")],
+            provider="openai",
+        )
+    ]
+    end = collected[-1]
+    assert isinstance(end, events.StreamEnd)
+    assert end.finish_reason == finish_reason
+    if finish_reason == "other":
+        assert end.provider_metadata == {
+            "openai": {"finish_reason": raw_finish_reason}
+        }
+    else:
+        assert end.provider_metadata is None
 
 
 async def test_responses_streams_function_tool_call() -> None:


### PR DESCRIPTION
- adds gen_ai semconv conversion to otel adapter for maximum downstream compatibility
- plumbs previously dropped values into spans: finish reason, response id/model, usage details