### PR TITLE
fix(openai): surface failed response streams

### DIFF
--- a/src/ai/providers/openai/protocol.py
+++ b/src/ai/providers/openai/protocol.py
@@ -22,6 +22,10 @@ if TYPE_CHECKING:
     import openai
     import pydantic
 
+_RETRYABLE_RESPONSE_ERROR_CODES = frozenset(
+    {"rate_limit_exceeded", "server_error", "vector_store_timeout"}
+)
+
 # ---------------------------------------------------------------------------
 # Message / tool conversion — internal types → OpenAI wire format
 # ---------------------------------------------------------------------------
@@ -1379,7 +1383,25 @@ async def _stream_responses(
                     response_metadata = _provider_metadata_for_response(
                         response
                     )
-                continue
+                    error = response.get("error")
+                else:
+                    error = None
+                if isinstance(error, Mapping):
+                    body: object = dict(error)
+                    message = error.get("message") or error.get("code") or error
+                    error_code = error.get("code")
+                    code = error_code if isinstance(error_code, str) else None
+                else:
+                    body = error if error is not None else response
+                    message = error or "OpenAI response failed"
+                    code = None
+                raise ai_errors.ProviderResponseError(
+                    str(message),
+                    provider=provider,
+                    body=body,
+                    code=code,
+                    is_retryable=(code in _RETRYABLE_RESPONSE_ERROR_CODES),
+                )
 
             if event_type == "error":
                 error = data.get("error")

--- a/tests/providers/openai/test_adapter.py
+++ b/tests/providers/openai/test_adapter.py
@@ -355,6 +355,100 @@ async def test_responses_streams_text_and_usage() -> None:
     }
 
 
+@pytest.mark.parametrize(
+    ("code", "message", "is_retryable"),
+    [
+        ("invalid_prompt", "The prompt could not be processed.", False),
+        ("rate_limit_exceeded", "Too many requests.", True),
+    ],
+)
+async def test_responses_failed_raises_provider_error(
+    code: str, message: str, is_retryable: bool
+) -> None:
+    fake, _ = _patch_responses(
+        [
+            {
+                "type": "response.failed",
+                "response": {
+                    "id": "resp_1",
+                    "status": "failed",
+                    "error": {
+                        "code": code,
+                        "message": message,
+                    },
+                },
+            }
+        ]
+    )
+
+    with pytest.raises(ai.ProviderResponseError) as exc_info:
+        await _drain(
+            protocol.OpenAIResponsesProtocol().stream(
+                fake,
+                _MODEL,
+                [ai.user_message("Hi")],
+                provider="openai",
+            )
+        )
+
+    exc = exc_info.value
+    assert exc.provider == "openai"
+    assert exc.code == code
+    assert exc.message == message
+    assert exc.is_retryable is is_retryable
+    assert exc.body == {
+        "code": code,
+        "message": message,
+    }
+
+
+async def test_responses_failed_preserves_partial_message() -> None:
+    fake, _ = _patch_responses(
+        [
+            {
+                "type": "response.output_item.added",
+                "output_index": 0,
+                "item": {
+                    "id": "msg_1",
+                    "type": "message",
+                    "role": "assistant",
+                },
+            },
+            {
+                "type": "response.output_text.delta",
+                "item_id": "msg_1",
+                "delta": "partial",
+            },
+            {
+                "type": "response.failed",
+                "response": {
+                    "id": "resp_1",
+                    "status": "failed",
+                    "error": {
+                        "code": "server_error",
+                        "message": "The model failed to generate a response.",
+                    },
+                },
+            },
+        ]
+    )
+    stream = ai.Stream(
+        protocol.OpenAIResponsesProtocol().stream(
+            fake,
+            _MODEL,
+            [ai.user_message("Hi")],
+            provider="openai",
+        )
+    )
+
+    with pytest.raises(ai.ProviderResponseError) as exc_info:
+        async for _ in stream:
+            pass
+
+    assert stream.text == "partial"
+    assert exc_info.value.is_retryable is True
+
+
 async def test_responses_streams_function_tool_call() -> None:
     fake, _ = _patch_responses(
         [


### PR DESCRIPTION
## What

Raise ProviderResponseError when the OpenAI Responses API emits response.failed. Preserve the provider error message, code, body, and retryability signal.

## Why

response.failed is a terminal provider failure, but the adapter currently continues and emits a normal StreamEnd. Applications can therefore persist partial output as a successful completion.

## How

- Convert the official response error payload into ProviderResponseError.
- Mark rate_limit_exceeded, server_error, and vector_store_timeout as retryable.
- Keep already streamed partial output available to the caller while raising.

OpenAI event reference: https://platform.openai.com/docs/api-reference/responses-streaming/response/failed

## Verification

- uv run --frozen pytest -q: 594 passed
- Ruff format and lint passed
- mypy passed
- ty passed

Suggested release label: fix.