### PR TITLE
Reject non-async tools in typing and at runtime

### DIFF
--- a/src/ai/agents/agent.py
+++ b/src/ai/agents/agent.py
@@ -1258,8 +1258,8 @@ async def _aggregate_from[T, S, R](
     agg = aggregator()
 
     rt = runtime.get_runtime()
-    async with util.maybe_aclosing(source) as src:
-        async for item in src:
+    async with util.maybe_aclosing(source):
+        async for item in source:
             agg.feed(item)
             await rt.put_event(
                 events_.PartialToolCallResult(

--- a/src/ai/agents/agent.py
+++ b/src/ai/agents/agent.py
@@ -10,6 +10,7 @@ import json
 import typing
 from collections.abc import (
     AsyncGenerator,
+    AsyncIterable,
     AsyncIterator,
     Awaitable,
     Callable,
@@ -364,7 +365,11 @@ def _stream_item_type(return_type: Any) -> Any:
     if typing.get_origin(resolved) is typing.Annotated:
         resolved = typing.get_args(resolved)[0]
 
-    if typing.get_origin(resolved) is not AsyncGenerator:
+    if typing.get_origin(resolved) not in (
+        AsyncGenerator,
+        AsyncIterator,
+        AsyncIterable,
+    ):
         return None
 
     args = typing.get_args(resolved)
@@ -454,7 +459,6 @@ class AgentTool:
     tool: Tool
     fn: Callable[..., Any]
     validator: type[pydantic.BaseModel] | None = None
-    is_gen: bool = False
     aggregator: Callable[[], events_.Aggregator[Any, Any, Any]] | None = None
     return_type: Any = None
 
@@ -489,7 +493,7 @@ def tool[**P, R](fn: Callable[P, Awaitable[R]], /) -> AgentTool: ...
 
 
 @overload
-def tool[**P, T](fn: Callable[P, AsyncGenerator[T]], /) -> AgentTool: ...
+def tool[**P, T](fn: Callable[P, AsyncIterable[T]], /) -> AgentTool: ...
 
 
 @overload
@@ -497,7 +501,9 @@ def tool[**P](
     *,
     require_approval: bool,
     return_type: Any = None,
-) -> Callable[[Callable[P, Any]], AgentTool]: ...
+) -> Callable[
+    [Callable[P, Awaitable[Any] | AsyncIterable[Any]]], AgentTool
+]: ...
 
 
 @overload
@@ -505,7 +511,9 @@ def tool[**P](
     *,
     return_type: Any,
     require_approval: bool = False,
-) -> Callable[[Callable[P, Any]], AgentTool]: ...
+) -> Callable[
+    [Callable[P, Awaitable[Any] | AsyncIterable[Any]]], AgentTool
+]: ...
 
 
 @overload
@@ -514,20 +522,18 @@ def tool[**P](
     aggregator: Callable[[], events_.Aggregator[Any, Any, Any]],
     require_approval: bool = False,
     return_type: Any = None,
-) -> Callable[[Callable[P, AsyncGenerator[Any]]], AgentTool]: ...
+) -> Callable[[Callable[P, AsyncIterable[Any]]], AgentTool]: ...
 
 
 def tool[**P, T, R](
-    fn: Callable[P, Awaitable[R]]
-    | Callable[P, AsyncGenerator[T]]
-    | None = None,
+    fn: Callable[P, Awaitable[R]] | Callable[P, AsyncIterable[T]] | None = None,
     /,
     *,
     aggregator: Callable[[], events_.Aggregator[Any, Any, Any]] | None = None,
     require_approval: bool = False,
     return_type: Any = None,
 ) -> (
-    Callable[[Callable[P, AsyncGenerator[Any]]], AgentTool]
+    Callable[[Callable[P, AsyncIterable[Any]]], AgentTool]
     | Callable[[Callable[P, Awaitable[R]]], AgentTool]
     | AgentTool
 ):
@@ -579,7 +585,6 @@ def tool[**P, T, R](
             tool=tool_decl,
             fn=fn,
             validator=validator,
-            is_gen=inspect.isasyncgenfunction(fn),
             aggregator=effective_aggregator,
             return_type=return_type
             or _tool_result_type_from_return_annotation(
@@ -682,24 +687,38 @@ class BoundToolCall:
             model_input: Any
             try:
                 kwargs = _validate_kwargs(tool, call.kwargs)
-                if tool.is_gen:
-                    # Generator tool (e.g. agent-as-a-tool): drain the async
-                    # generator, forward each yielded value to the runtime for
+                # The returned value decides how the tool runs, so a
+                # plain `def` returning a coroutine works too.
+                returned = tool.fn(**kwargs)
+                if isinstance(returned, AsyncIterable):
+                    # Streaming tool (e.g. agent-as-a-tool): drain the async
+                    # iterable, forward each yielded value to the runtime for
                     # real-time streaming, then capture both the aggregator
                     # snapshot (the rich shape that flows to the UI) and the
                     # model-facing value (what the LLM sees on its next turn).
-                    assert tool.aggregator
+                    if tool.aggregator is None:
+                        raise TypeError(
+                            f"tool {tool.name!r} streams but declares no "
+                            f"aggregator; pass `aggregator=` or annotate its "
+                            f"return type with an Aggregate marker"
+                        )
                     agg = await _aggregate_from(
-                        tool.fn(**kwargs),
+                        returned,
                         tool_call_id=call.tool_call_id,
                         tool_name=call.tool_name,
                         aggregator=tool.aggregator,
                     )
                     result = agg.snapshot()
                     model_input = agg.get_model_input()
-                else:
-                    result = await tool.fn(**kwargs)
+                elif inspect.isawaitable(returned):
+                    result = await returned
                     model_input = result
+                else:
+                    raise TypeError(
+                        f"tool {tool.name!r} must return an awaitable or an "
+                        f"async iterable, not {type(returned).__name__}; "
+                        f"declare it with `async def`"
+                    )
             except Exception as exc:
                 return _error_tool_result(
                     exc,
@@ -1181,7 +1200,7 @@ def deferred_tool_result(
 
 
 async def yield_from[T, S, R](
-    source: AsyncGenerator[T],
+    source: AsyncIterable[T],
     *,
     aggregator: Callable[[], events_.Aggregator[T, S, R]],
     # TODO: is this what we really want for labelling?
@@ -1222,7 +1241,7 @@ async def yield_from[T, S, R](
 
 
 async def _aggregate_from[T, S, R](
-    source: AsyncGenerator[T],
+    source: AsyncIterable[T],
     *,
     aggregator: Callable[[], events_.Aggregator[T, S, R]],
     tool_name: str | None = None,
@@ -1239,7 +1258,7 @@ async def _aggregate_from[T, S, R](
     agg = aggregator()
 
     rt = runtime.get_runtime()
-    async with contextlib.aclosing(source) as src:
+    async with util.maybe_aclosing(source) as src:
         async for item in src:
             agg.feed(item)
             await rt.put_event(

--- a/src/ai/util.py
+++ b/src/ai/util.py
@@ -165,9 +165,9 @@ class TaskGroup(asyncio.TaskGroup):
 
 
 @contextlib.asynccontextmanager
-async def maybe_aclosing[T](
-    iter: AsyncIterable[T],
-) -> AsyncIterator[AsyncIterable[T]]:
+async def maybe_aclosing(
+    iter: AsyncIterable[Any],
+) -> AsyncIterator[AsyncIterable[Any]]:
     """Like ``contextlib.aclosing`` but a no-op if ``iter`` has no ``aclose``.
 
     Useful when consuming an arbitrary ``AsyncIterable[T]`` whose concrete

--- a/src/ai/util.py
+++ b/src/ai/util.py
@@ -165,9 +165,9 @@ class TaskGroup(asyncio.TaskGroup):
 
 
 @contextlib.asynccontextmanager
-async def maybe_aclosing(
-    iter: AsyncIterable[Any],
-) -> AsyncIterator[AsyncIterable[Any]]:
+async def maybe_aclosing[T](
+    iter: AsyncIterable[T],
+) -> AsyncIterator[AsyncIterable[T]]:
     """Like ``contextlib.aclosing`` but a no-op if ``iter`` has no ``aclose``.
 
     Useful when consuming an arbitrary ``AsyncIterable[T]`` whose concrete

--- a/tests/agents/test_generator_tools.py
+++ b/tests/agents/test_generator_tools.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import AsyncGenerator, Sequence
+from collections.abc import AsyncGenerator, AsyncIterator, Sequence
 from typing import Any
 
 import pydantic
@@ -74,6 +74,67 @@ async def test_generator_tool_streams_and_returns_result() -> None:
     assert len(tool_results) >= 1
     tr = tool_results[0].results[0].result
     assert tr == "Answer for test"
+
+
+# ---------------------------------------------------------------------------
+# Streaming is keyed on being async-iterable, not on being a generator
+# ---------------------------------------------------------------------------
+
+
+class _Chunks:
+    """Async-iterable but not an async generator -- ``__aiter__`` hands
+    back the generator, the shape ``ToolRunner.events()`` has."""
+
+    def __init__(self, *items: str) -> None:
+        self._items = items
+
+    async def _gen(self) -> AsyncIterator[str]:
+        for item in self._items:
+            yield item
+
+    def __aiter__(self) -> AsyncIterator[str]:
+        return self._gen()
+
+
+@ai.tool(aggregator=ai.agents.ConcatAggregator)
+def spell_tool(word: str) -> _Chunks:
+    """Spell a word out, one letter at a time."""
+    return _Chunks(*word)
+
+
+async def test_async_iterable_tool_streams_like_a_generator() -> None:
+    my_agent = ai.Agent(tools=[spell_tool])
+    llm = mock_llm(
+        [
+            [
+                tool_call_msg(
+                    tc_id="tc-1", name="spell_tool", args='{"word": "abc"}'
+                )
+            ],
+            [text_msg("Done!", id="msg-2")],
+        ]
+    )
+
+    all_events: list[agent_events_.AgentEvent] = []
+    async with my_agent.run(MOCK_MODEL, [ai.user_message("Go")]) as stream:
+        async for event in stream:
+            all_events.append(event)
+
+    assert llm.call_count == 2
+
+    # Each letter reached the consumer as it was produced...
+    partials = [
+        e.value
+        for e in all_events
+        if isinstance(e, agent_events_.PartialToolCallResult)
+    ]
+    assert partials == ["a", "b", "c"]
+
+    # ...and the aggregated value is what the LLM sees.
+    tool_results = [
+        e for e in all_events if isinstance(e, agent_events_.ToolCallResult)
+    ]
+    assert tool_results[0].results[0].result == "abc"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/agents/test_tools.py
+++ b/tests/agents/test_tools.py
@@ -3,12 +3,20 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Callable
 from typing import Any, cast
 
 import pydantic
 import pytest
 
 import ai
+
+# Declaring a tool with a plain `def` is a type error by design; go
+# through an untyped view of the decorator to reach the runtime check.
+_untyped_tool = cast(
+    "Callable[[Callable[..., Any]], ai.AgentTool]",
+    ai.tool,
+)
 
 # -- Schema extraction from type hints ------------------------------------
 
@@ -160,6 +168,67 @@ async def test_tool_call_unwraps_singleton_exceptiongroup() -> None:
     assert "BoomError" in str(result.results[0].result)
     assert "kaboom" in str(result.results[0].result)
     assert isinstance(result.exception, BoomError)
+
+
+async def test_sync_tool_says_what_is_wrong() -> None:
+    # Typing rejects a plain `def` tool; if one gets through anyway, the
+    # failure names the tool instead of "object int can't be used in
+    # 'await' expression".
+    @_untyped_tool
+    def add(a: int, b: int) -> int:
+        """Add two numbers."""
+        return a + b
+
+    part = ai.messages.ToolCallPart(
+        tool_call_id="tc-sync",
+        tool_name="add",
+        tool_args='{"a": 1, "b": 2}',
+    )
+    result = await ai.agents.BoundToolCall(part=part, tool=add)()
+
+    assert result.results[0].is_error
+    assert "must return an awaitable" in str(result.results[0].result)
+    assert "'add'" in str(result.results[0].result)
+    assert isinstance(result.exception, TypeError)
+
+
+async def test_plain_def_returning_a_coroutine_runs() -> None:
+    # The check is on the returned value, not on how the tool is
+    # declared, so a `def` that hands back a coroutine is fine.
+    async def _add(a: int, b: int) -> int:
+        return a + b
+
+    @_untyped_tool
+    def add(a: int, b: int) -> Any:
+        """Add two numbers."""
+        return _add(a, b)
+
+    part = ai.messages.ToolCallPart(
+        tool_call_id="tc-coro",
+        tool_name="add",
+        tool_args='{"a": 1, "b": 2}',
+    )
+    result = await ai.agents.BoundToolCall(part=part, tool=add)()
+
+    assert not result.results[0].is_error
+    assert result.results[0].result == 3
+
+
+async def test_generator_tool_without_aggregator_says_so() -> None:
+    @_untyped_tool
+    async def stream(x: int) -> Any:
+        """Streams without declaring an aggregator."""
+        yield x
+
+    part = ai.messages.ToolCallPart(
+        tool_call_id="tc-gen",
+        tool_name="stream",
+        tool_args='{"x": 1}',
+    )
+    result = await ai.agents.BoundToolCall(part=part, tool=stream)()
+
+    assert result.results[0].is_error
+    assert "declares no aggregator" in str(result.results[0].result)
 
 
 async def test_tool_call_allows_kwarg_overrides() -> None:


### PR DESCRIPTION
The keyword forms of `@tool` accepted any callable; they now require an awaitable or an async iterable, like the bare form already did.

At runtime the returned value picks the path: an async iterable streams through the aggregator, an awaitable is awaited, anything else raises a TypeError naming the tool instead of "object int can't be used in 'await' expression". A plain `def` handing back a coroutine still works.

Streaming keys on AsyncIterable rather than async generators, so _aggregate_from drains through util.maybe_aclosing.