### PR TITLE
Add trace_attrs for propagating user data

### DIFF
--- a/docs/ai-python/content/docs/reference/telemetry.mdx
+++ b/docs/ai-python/content/docs/reference/telemetry.mdx
@@ -41,6 +41,7 @@ It is a Pydantic model, generic in its data type: `Span[SpanData]`.
 | `replay` | `True` when the work is being [replayed](/docs/reference/ai/stream#replay) rather than performed live (resume, serverless re-entry). |
 | `set_as_current` | Whether the span sets itself as current. Adapters should respect it to keep nesting consistent. |
 | `events` | List of `SpanEvent` milestones. |
+| `trace_attrs` | User data propagated down the trace: a child gets a copy of its parent's `trace_attrs` at creation. |
 
 The lifecycle is encoded in the timestamps:
 
@@ -198,8 +199,9 @@ sink with `Span.push()`.
 The framework provides utilities to make this less verbose, as well as to make those
 manual spans play nice with the built-in instrumentation.
 
-1. `create_span()` mints identity and takes the trace id and parentage from
-   `parent` (default: the current span; a fresh trace when there is none). Nothing is reported.
+1. `create_span()` mints identity and takes the trace id, parentage, and a copy of
+   `trace_attrs` from `parent` (default: the current span; a fresh trace when there
+   is none). Nothing is reported.
 2. `stamp_start()` and `stamp_end()` write timestamps from the ambient clock. 
    `stamp_end(error=...)` also records an error when given one, converting an
    exception to a `SpanError`. Still nothing is reported.
@@ -391,8 +393,8 @@ and `gen_ai.tool.*` (name, call id, description). Failed spans set
 `error.type` and an error status. Model call spans export with the `CLIENT`
 span kind; agent and tool spans stay `INTERNAL`.
 
-Custom span attributes export as-is; values that are not scalars are
-converted with `repr`.
+Custom span attributes and `trace_attrs` export as-is; values that are not
+scalars are converted with `repr`.
 
 ### Capture message content
 

--- a/src/ai/experimental_telemetry/otel.py
+++ b/src/ai/experimental_telemetry/otel.py
@@ -281,7 +281,14 @@ def _semconv_tool_definitions(names: list[str]) -> str:
 
 
 def _attributes(sp: telemetry.Span, *, capture_content: bool) -> dict[str, Any]:
-    attrs: dict[str, Any] = {}
+    # process trace_attrs
+    attrs: dict[str, Any] = {
+        # otel only allows scalar attribute values or lists of them
+        key: value
+        if isinstance(value, str | bool | int | float)
+        else repr(value)
+        for key, value in sp.trace_attrs.items()
+    }
     if sp.replay:
         attrs["ai.replay"] = True
     match sp.data:

--- a/src/ai/experimental_telemetry/span.py
+++ b/src/ai/experimental_telemetry/span.py
@@ -407,6 +407,9 @@ class Span(pydantic.BaseModel, Generic[DataT_co]):
     Adapters must not make those spans "current" either to avoid
     nesting discrepancies.
 
+    ``trace_attrs`` is user data that propagates down from parent to child
+    on creation.
+
     ``schema_version`` tracks the shape of spans and their data types.
     """
 
@@ -421,8 +424,9 @@ class Span(pydantic.BaseModel, Generic[DataT_co]):
     replay: bool = False
     set_as_current: bool = True
     events: list[SpanEvent] = pydantic.Field(default_factory=list)
+    trace_attrs: dict[str, Any] = pydantic.Field(default_factory=dict)
 
-    schema_version: ClassVar[int] = 4
+    schema_version: ClassVar[int] = 5
 
     def set_attrs(
         self, attrs: Mapping[str, Any] | None = None, /, **kwargs: Any
@@ -786,9 +790,10 @@ def create_span(
 ) -> Span[Any]:
     """Create a span: identity only, nothing is reported.
 
-    Mints the span id, and takes trace id and parentage from ``parent``
-    (default: the current span; a fresh trace when there is none).
-    ``parent`` may be a span restored from JSON.
+    Mints the span id, and takes trace id, parentage, and a copy of
+    ``trace_attrs`` from ``parent`` (default: the current span; a fresh
+    trace when there is none).  ``parent`` may be a span restored from
+    JSON.
 
     The span has no timestamps yet: :meth:`Span.stamp_start` and
     :meth:`Span.push` when the work begins, or hand the whole
@@ -817,8 +822,10 @@ def create_span(
         parent = _current.get()
     if parent is None:
         trace_id, parent_id = messages_.generate_id("trace"), None
+        trace_attrs: dict[str, Any] = {}
     else:
         trace_id, parent_id = parent.trace_id, parent.id
+        trace_attrs = dict(parent.trace_attrs)
     return Span(
         name=name,
         data=data,
@@ -827,6 +834,7 @@ def create_span(
         parent_id=parent_id,
         replay=replay,
         set_as_current=set_as_current,
+        trace_attrs=trace_attrs,
     )
 
 

--- a/tests/experimental_telemetry/test_otel.py
+++ b/tests/experimental_telemetry/test_otel.py
@@ -53,6 +53,23 @@ async def test_nesting_names_and_attributes(
     assert outer.attributes["foo"] == "bar"
 
 
+async def test_trace_attrs_exported_on_every_span(
+    otel_env: tuple[InMemorySpanExporter, TracerProvider],
+) -> None:
+    exporter, _ = otel_env
+    async with ai.experimental_telemetry.span("outer") as sp:
+        sp.trace_attrs["session.id"] = "s-1"
+        sp.trace_attrs["obj"] = {"a": 1}  # non-scalar: exported as repr
+        async with ai.experimental_telemetry.span("inner"):
+            pass
+
+    spans = {s.name: s for s in exporter.get_finished_spans()}
+    for span in spans.values():
+        assert span.attributes is not None
+        assert span.attributes["session.id"] == "s-1"
+        assert span.attributes["obj"] == repr({"a": 1})
+
+
 async def test_model_call_attributes(
     otel_env: tuple[InMemorySpanExporter, TracerProvider],
 ) -> None:

--- a/tests/experimental_telemetry/test_telemetry.py
+++ b/tests/experimental_telemetry/test_telemetry.py
@@ -224,6 +224,42 @@ async def test_restored_span_parent_continues_trace(
             assert nested.parent_id == pickup.id
 
 
+async def test_trace_attrs_propagate_to_children(recorder: Recorder) -> None:
+    async with ai.experimental_telemetry.span("root") as root:
+        root.trace_attrs["session.id"] = "s-1"
+        async with ai.experimental_telemetry.span("child") as child:
+            # A copy of the parent's attrs at creation time...
+            assert child.trace_attrs == {"session.id": "s-1"}
+            async with ai.experimental_telemetry.span("grandchild") as gc:
+                assert gc.trace_attrs == {"session.id": "s-1"}
+            # ...independent of the parent's dict.
+            child.trace_attrs["extra"] = True
+        assert root.trace_attrs == {"session.id": "s-1"}
+        # Later mutations reach spans created afterwards, not before.
+        root.trace_attrs["user.id"] = "u-1"
+        async with ai.experimental_telemetry.span("sibling") as sibling:
+            assert sibling.trace_attrs == {
+                "session.id": "s-1",
+                "user.id": "u-1",
+            }
+        assert child.trace_attrs == {"session.id": "s-1", "extra": True}
+
+
+async def test_trace_attrs_survive_restore(recorder: Recorder) -> None:
+    # "Process one": trace_attrs travel inside the serialized span.
+    async with ai.experimental_telemetry.span("origin") as origin:
+        origin.trace_attrs["session.id"] = "s-1"
+        payload = origin.model_dump(mode="json")
+
+    # "Process two": children of the restored span inherit them.
+    restored = ai.experimental_telemetry.Span.model_validate(payload)
+    assert restored.trace_attrs == {"session.id": "s-1"}
+    async with ai.experimental_telemetry.span(
+        "pickup", parent=restored
+    ) as pickup:
+        assert pickup.trace_attrs == {"session.id": "s-1"}
+
+
 async def test_use_span_parents_without_lifecycle(
     recorder: Recorder,
 ) -> None:


### PR DESCRIPTION
Adds `trace_attrs` on span that propagates from parent to child. This enables users to set something like `session_id` on a trace and have it be propagated all the way down (necessary for Langfuse for example).