### PR TITLE
ui: emit step boundaries after a StreamEnd

### DIFF
--- a/src/ai/ui/ai_sdk/outbound_stream.py
+++ b/src/ai/ui/ai_sdk/outbound_stream.py
@@ -110,6 +110,16 @@ class _StreamState:
         self.open_text_ids.clear()
         return events
 
+    def _ensure_step(
+        self,
+    ) -> list[ui_events.UIMessageStreamEvent]:
+        events: list[ui_events.UIMessageStreamEvent] = []
+        if not self.in_step:
+            events.append(ui_events.UIStartStepEvent())
+            self.in_step = True
+
+        return events
+
     def _ensure_started(
         self,
         message_id: str | None = None,
@@ -120,15 +130,22 @@ class _StreamState:
         if not self.emitted_start:
             self.ui_message_id = message_id
             events.append(ui_events.UIStartEvent(message_id=self.ui_message_id))
-            events.append(ui_events.UIStartStepEvent())
             self.emitted_start = True
-            self.in_step = True
             self.started_tool_inputs.clear()
             self.tool_names.clear()
             self.input_available_emitted.clear()
             self.emitted_tool_results.clear()
             self.emitted_approval_requests.clear()
 
+        events.extend(self._ensure_step())
+
+        return events
+
+    def _end_step(self) -> list[ui_events.UIMessageStreamEvent]:
+        events: list[ui_events.UIMessageStreamEvent] = []
+        if self.emitted_start and self.in_step:
+            events.append(ui_events.UIFinishStepEvent())
+            self.in_step = False
         return events
 
     # -- phase: streaming events --------------------------------------------
@@ -149,8 +166,17 @@ class _StreamState:
                 elif message.id != "<unset>":
                     message_id = message.id
             out.extend(self._ensure_started(message_id))
+        else:
+            out.extend(self._ensure_step())
 
         match event:
+            case events_.StreamEnd():
+                # Close out steps on a StreamEnd. This gives a bit
+                # more structure to the output, and makes it easy find
+                # the splits between assistant turns and tool
+                # running.
+                out.extend(self._end_step())
+
             case events_.TextStart(block_id=pid):
                 self.open_text_ids.add(pid)
                 out.append(

--- a/tests/ui/ai_sdk/test_outbound_stream.py
+++ b/tests/ui/ai_sdk/test_outbound_stream.py
@@ -574,6 +574,43 @@ async def test_resolved_approval_hook_emits_response_event() -> None:
     assert any(isinstance(p, ui_events.UIToolOutputDeniedEvent) for p in out)
 
 
+async def test_stream_end_closes_step_and_next_event_reopens_it() -> None:
+    """StreamEnd finishes the current step; the next event starts a new one."""
+    out = await _collect(
+        [
+            events_.TextStart(block_id="t1"),
+            events_.TextDelta(block_id="t1", chunk="hi"),
+            events_.TextEnd(block_id="t1"),
+            events_.StreamEnd(),
+            events_.ToolStart(tool_call_id="tc1", tool_name="search"),
+            events_.ToolDelta(tool_call_id="tc1", chunk="{}"),
+            events_.ToolEnd(
+                tool_call_id="tc1",
+                tool_call=messages_.ToolCallPart(
+                    tool_call_id="tc1",
+                    tool_name="search",
+                    tool_args="{}",
+                ),
+            ),
+        ]
+    )
+
+    types = [type(event).__name__ for event in out]
+    assert types == [
+        "UIStartEvent",
+        "UIStartStepEvent",
+        "UITextStartEvent",
+        "UITextDeltaEvent",
+        "UITextEndEvent",
+        "UIFinishStepEvent",
+        "UIStartStepEvent",
+        "UIToolInputStartEvent",
+        "UIToolInputDeltaEvent",
+        "UIFinishStepEvent",
+        "UIFinishEvent",
+    ]
+
+
 # NOTE: agent-change boundary detection used to be driven by
 # Message.source_label.  That field has been removed; agent-change
 # routing in the AI SDK adapter now needs to come from


### PR DESCRIPTION
This gives a clear step boundary between assistant responses and tool
calls.

The ai-sdk *workflow* agent does this, the stock one does not.

I want this because it will make it fairly easy for a workflow-based
app to signal to a client that the currently streaming assistant step
has failed and is being retried.
