### PR TITLE
ui: trigger step boundaries on a StreamBegin, not a StreamEnd

### DIFF
--- a/src/ai/ui/ai_sdk/outbound_stream.py
+++ b/src/ai/ui/ai_sdk/outbound_stream.py
@@ -57,6 +57,7 @@ class _StreamState:
         self.ui_message_id: str | None = None
         self.emitted_start: bool = False
         self.in_step: bool = False
+        self.step_ended: bool = False
 
         self.started_tool_inputs: set[str] = set()
         self.tool_names: dict[str, str] = {}
@@ -110,16 +111,6 @@ class _StreamState:
         self.open_text_ids.clear()
         return events
 
-    def _ensure_step(
-        self,
-    ) -> list[ui_events.UIMessageStreamEvent]:
-        events: list[ui_events.UIMessageStreamEvent] = []
-        if not self.in_step:
-            events.append(ui_events.UIStartStepEvent())
-            self.in_step = True
-
-        return events
-
     def _ensure_started(
         self,
         message_id: str | None = None,
@@ -137,15 +128,10 @@ class _StreamState:
             self.emitted_tool_results.clear()
             self.emitted_approval_requests.clear()
 
-        events.extend(self._ensure_step())
+        if not self.in_step:
+            events.append(ui_events.UIStartStepEvent())
+            self.in_step = True
 
-        return events
-
-    def _end_step(self) -> list[ui_events.UIMessageStreamEvent]:
-        events: list[ui_events.UIMessageStreamEvent] = []
-        if self.emitted_start and self.in_step:
-            events.append(ui_events.UIFinishStepEvent())
-            self.in_step = False
         return events
 
     # -- phase: streaming events --------------------------------------------
@@ -166,16 +152,20 @@ class _StreamState:
                 elif message.id != "<unset>":
                     message_id = message.id
             out.extend(self._ensure_started(message_id))
-        else:
-            out.extend(self._ensure_step())
 
         match event:
             case events_.StreamEnd():
-                # Close out steps on a StreamEnd. This gives a bit
-                # more structure to the output, and makes it easy find
-                # the splits between assistant turns and tool
-                # running.
-                out.extend(self._end_step())
+                self.step_ended = True
+
+            case events_.StreamStart():
+                # If we have seen an earlier StreamEnd, then we want
+                # to close out the current step on a StreamStart and
+                # start a new one.  This makes it easy to find the
+                # start of each assistant turn.
+                if self.step_ended:
+                    self.step_ended = False
+                    out.append(ui_events.UIFinishStepEvent())
+                    out.append(ui_events.UIStartStepEvent())
 
             case events_.TextStart(block_id=pid):
                 self.open_text_ids.add(pid)

--- a/tests/ui/ai_sdk/test_outbound_stream.py
+++ b/tests/ui/ai_sdk/test_outbound_stream.py
@@ -574,14 +574,15 @@ async def test_resolved_approval_hook_emits_response_event() -> None:
     assert any(isinstance(p, ui_events.UIToolOutputDeniedEvent) for p in out)
 
 
-async def test_stream_end_closes_step_and_next_event_reopens_it() -> None:
-    """StreamEnd finishes the current step; the next event starts a new one."""
+async def test_stream_start_after_stream_end_reopens_step() -> None:
+    """A new model stream starts a new UI step after StreamEnd."""
     out = await _collect(
         [
             events_.TextStart(block_id="t1"),
             events_.TextDelta(block_id="t1", chunk="hi"),
             events_.TextEnd(block_id="t1"),
             events_.StreamEnd(),
+            events_.StreamStart(),
             events_.ToolStart(tool_call_id="tc1", tool_name="search"),
             events_.ToolDelta(tool_call_id="tc1", chunk="{}"),
             events_.ToolEnd(


### PR DESCRIPTION
In #237 we started emitting a step-finish immediately at a StreamEnd.

This caused some grief because it meant that tool approvals might show
up in a different step than the tool calls, which broke things with
useChat.

So instead we make sure to put the boundary at a StreamBegin; if there
was previously a StreamEnd, then we'll emit a step-finish/step-start
pair.
