### PR TITLE
Clean up examples dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
 
       - run: uv run ruff format --check src tests examples
       - run: uv run ruff check src tests examples
-      - run: uv run mypy
+      - run: uv run mypy src tests
       - run: uv run ty check
 
       - run: uv run pytest

--- a/examples/.test_scripts/check-examples.py
+++ b/examples/.test_scripts/check-examples.py
@@ -5,6 +5,7 @@ Usage (from repo root):
     uv run examples/.test_scripts/check-examples.py
 """
 
+import argparse
 import os
 import subprocess
 import sys
@@ -49,7 +50,9 @@ EXAMPLES: list[tuple[str, Path, list[str]]] = [
 ]
 
 
-def run_mypy(name: str, directory: Path, targets: list[str]) -> bool:
+def run_mypy(
+    name: str, directory: Path, targets: list[str], *, use_current_ai: bool
+) -> bool:
     header = f"{'=' * 20} {name} {'=' * 20}"
     print(header)
 
@@ -57,20 +60,18 @@ def run_mypy(name: str, directory: Path, targets: list[str]) -> bool:
     for dep in [MYPY_VERSION]:
         with_args.extend(["--with", dep])
 
-    cmd = [
-        "uv",
-        "run",
-        "--frozen",
-        "--group",
-        "dev",
-        "--with-editable",
-        str(REPO),
-        *with_args,
-        "mypy",
-        "--config-file",
-        str(REPO / "pyproject.toml"),
-        *targets,
-    ]
+    cmd = ["uv", "run", "--frozen", "--group", "dev"]
+    if use_current_ai:
+        cmd.extend(["--with-editable", str(REPO)])
+    cmd.extend(
+        [
+            *with_args,
+            "mypy",
+            "--config-file",
+            str(REPO / "pyproject.toml"),
+            *targets,
+        ]
+    )
 
     env = {k: v for k, v in os.environ.items() if k != "VIRTUAL_ENV"}
     sys.stdout.flush()
@@ -81,9 +82,19 @@ def run_mypy(name: str, directory: Path, targets: list[str]) -> bool:
 
 
 def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--no-current-ai",
+        action="store_true",
+        help="check against the ai version specified by each example",
+    )
+    args = parser.parse_args()
+
     results: list[tuple[str, bool]] = []
     for name, directory, targets in EXAMPLES:
-        ok = run_mypy(name, directory, targets)
+        ok = run_mypy(
+            name, directory, targets, use_current_ai=not args.no_current_ai
+        )
         results.append((name, ok))
 
     print("=" * 60)

--- a/examples/.test_scripts/check-examples.py
+++ b/examples/.test_scripts/check-examples.py
@@ -50,10 +50,15 @@ EXAMPLES: list[tuple[str, Path, list[str]]] = [
 ]
 
 
-def run_mypy(
-    name: str, directory: Path, targets: list[str], *, use_current_ai: bool
+def run_checker(
+    checker: list[str],
+    name: str,
+    directory: Path,
+    targets: list[str],
+    *,
+    use_current_ai: bool,
 ) -> bool:
-    header = f"{'=' * 20} {name} {'=' * 20}"
+    header = f"{'=' * 20} {name} ({checker[0]}) {'=' * 20}"
     print(header)
 
     with_args: list[str] = []
@@ -66,9 +71,7 @@ def run_mypy(
     cmd.extend(
         [
             *with_args,
-            "mypy",
-            "--config-file",
-            str(REPO / "pyproject.toml"),
+            *checker,
             *targets,
         ]
     )
@@ -79,6 +82,12 @@ def run_mypy(
     print()
     sys.stdout.flush()
     return result.returncode == 0
+
+
+CHECKERS = [
+    ["mypy", "--config-file", str(REPO / "pyproject.toml")],
+    ["ty", "check"],
+]
 
 
 def main() -> None:
@@ -92,10 +101,15 @@ def main() -> None:
 
     results: list[tuple[str, bool]] = []
     for name, directory, targets in EXAMPLES:
-        ok = run_mypy(
-            name, directory, targets, use_current_ai=not args.no_current_ai
-        )
-        results.append((name, ok))
+        for checker in CHECKERS:
+            ok = run_checker(
+                checker,
+                name,
+                directory,
+                targets,
+                use_current_ai=not args.no_current_ai,
+            )
+            results.append((f"{name} ({checker[0]})", ok))
 
     print("=" * 60)
     print("Summary:")

--- a/examples/apps/coding_agent/pyproject.toml
+++ b/examples/apps/coding_agent/pyproject.toml
@@ -11,6 +11,3 @@ dependencies = [
 
 [tool.uv]
 exclude-newer = "2 days"
-
-[tool.uv.sources]
-ai = { path = "../../..", editable = true }

--- a/examples/apps/coding_agent/uv.lock
+++ b/examples/apps/coding_agent/uv.lock
@@ -8,45 +8,17 @@ exclude-newer-span = "P2D"
 
 [[package]]
 name = "ai"
-source = { editable = "../../../" }
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
     { name = "modelsdotdev" },
     { name = "pydantic" },
     { name = "typing-extensions" },
 ]
-
-[package.metadata]
-requires-dist = [
-    { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.83.0" },
-    { name = "httpx", specifier = ">=0.28.1" },
-    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.18.0" },
-    { name = "modelsdotdev", specifier = "==0.*" },
-    { name = "openai", marker = "extra == 'openai'", specifier = ">=2.14.0" },
-    { name = "pydantic", specifier = ">=2.13" },
-    { name = "typing-extensions", specifier = ">=4.15.0" },
-]
-provides-extras = ["anthropic", "mcp", "openai"]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "anthropic", specifier = ">=0.83.0" },
-    { name = "async-solipsism", specifier = ">=0.9" },
-    { name = "mcp", specifier = ">=1.18.0" },
-    { name = "mypy", specifier = "~=2.1.0" },
-    { name = "openai", specifier = ">=2.14.0" },
-    { name = "pytest", specifier = ">=8.0" },
-    { name = "pytest-asyncio", specifier = ">=0.24" },
-    { name = "python-dotenv", specifier = ">=1.2.1" },
-    { name = "rich", specifier = ">=14.2.0" },
-    { name = "ruff", specifier = "~=0.8.0" },
-    { name = "ty", specifier = "~=0.0.37" },
-]
-examples = [
-    { name = "fastapi", specifier = ">=0.136.1" },
-    { name = "temporalio", specifier = ">=1.27.2" },
-    { name = "textual", specifier = ">=8.2.6" },
-    { name = "websockets", specifier = ">=16.0" },
+sdist = { url = "https://files.pythonhosted.org/packages/a1/64/e4fb93545d0bded3a826aa6b9bf7a1154fa67d9f559ad833f59e75778353/ai-0.4.0.tar.gz", hash = "sha256:9b1292d9615b0867591541fc9b82add25a002d78cb6a1c4ed18fb5bc8f217f3f", size = 1181865, upload-time = "2026-07-28T17:56:24.719Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/64/4e70ac7aa8fc6ad586d066cf5d1df853989cb80fd40d12a88172bf26885f/ai-0.4.0-py3-none-any.whl", hash = "sha256:39fb560872c34c43eda400ea1fc6bc4e1488f118f2efb850713677735e31459f", size = 179587, upload-time = "2026-07-28T17:56:23.63Z" },
 ]
 
 [[package]]
@@ -92,7 +64,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "ai", editable = "../../../" },
+    { name = "ai" },
     { name = "rich", specifier = ">=14.0" },
     { name = "textual", specifier = ">=8.2" },
 ]

--- a/examples/apps/durable_agent_temporal/backend/pyproject.toml
+++ b/examples/apps/durable_agent_temporal/backend/pyproject.toml
@@ -38,9 +38,6 @@ select = ["E", "F", "I", "UP", "B", "SIM"]
 [tool.uv]
 exclude-newer = "2 days"
 
-[tool.uv.sources]
-ai = { path = "../../../..", editable = true }
-
 [dependency-groups]
 dev = [
     "mypy>=1.19.1",

--- a/examples/apps/durable_agent_temporal/backend/uv.lock
+++ b/examples/apps/durable_agent_temporal/backend/uv.lock
@@ -14,45 +14,17 @@ exclude-newer-span = "P2D"
 
 [[package]]
 name = "ai"
-source = { editable = "../../../../" }
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
     { name = "modelsdotdev" },
     { name = "pydantic" },
     { name = "typing-extensions" },
 ]
-
-[package.metadata]
-requires-dist = [
-    { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.83.0" },
-    { name = "httpx", specifier = ">=0.28.1" },
-    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.18.0" },
-    { name = "modelsdotdev", specifier = "==0.*" },
-    { name = "openai", marker = "extra == 'openai'", specifier = ">=2.14.0" },
-    { name = "pydantic", specifier = ">=2.13" },
-    { name = "typing-extensions", specifier = ">=4.15.0" },
-]
-provides-extras = ["anthropic", "mcp", "openai"]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "anthropic", specifier = ">=0.83.0" },
-    { name = "async-solipsism", specifier = ">=0.9" },
-    { name = "mcp", specifier = ">=1.18.0" },
-    { name = "mypy", specifier = "~=2.1.0" },
-    { name = "openai", specifier = ">=2.14.0" },
-    { name = "pytest", specifier = ">=8.0" },
-    { name = "pytest-asyncio", specifier = ">=0.24" },
-    { name = "python-dotenv", specifier = ">=1.2.1" },
-    { name = "rich", specifier = ">=14.2.0" },
-    { name = "ruff", specifier = "~=0.8.0" },
-    { name = "ty", specifier = "~=0.0.37" },
-]
-examples = [
-    { name = "fastapi", specifier = ">=0.136.1" },
-    { name = "temporalio", specifier = ">=1.27.2" },
-    { name = "textual", specifier = ">=8.2.6" },
-    { name = "websockets", specifier = ">=16.0" },
+sdist = { url = "https://files.pythonhosted.org/packages/a1/64/e4fb93545d0bded3a826aa6b9bf7a1154fa67d9f559ad833f59e75778353/ai-0.4.0.tar.gz", hash = "sha256:9b1292d9615b0867591541fc9b82add25a002d78cb6a1c4ed18fb5bc8f217f3f", size = 1181865, upload-time = "2026-07-28T17:56:24.719Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/64/4e70ac7aa8fc6ad586d066cf5d1df853989cb80fd40d12a88172bf26885f/ai-0.4.0-py3-none-any.whl", hash = "sha256:39fb560872c34c43eda400ea1fc6bc4e1488f118f2efb850713677735e31459f", size = 179587, upload-time = "2026-07-28T17:56:23.63Z" },
 ]
 
 [[package]]
@@ -195,7 +167,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "ai", editable = "../../../../" },
+    { name = "ai" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.115.0" },
     { name = "temporalio", specifier = ">=1.9.0" },
 ]

--- a/examples/apps/durable_agent_workflows/backend/pyproject.toml
+++ b/examples/apps/durable_agent_workflows/backend/pyproject.toml
@@ -34,9 +34,6 @@ select = ["E", "F", "I", "UP", "B", "SIM"]
 [tool.uv]
 exclude-newer = "2 days"
 
-[tool.uv.sources]
-ai = { path = "../../../..", editable = true }
-
 [dependency-groups]
 dev = [
     "mypy>=1.19.1",

--- a/examples/apps/durable_agent_workflows/backend/uv.lock
+++ b/examples/apps/durable_agent_workflows/backend/uv.lock
@@ -13,50 +13,17 @@ exclude-newer-span = "P2D"
 
 [[package]]
 name = "ai"
-source = { editable = "../../../../" }
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
     { name = "modelsdotdev" },
     { name = "pydantic" },
     { name = "typing-extensions" },
 ]
-
-[package.metadata]
-requires-dist = [
-    { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.83.0" },
-    { name = "httpx", specifier = ">=0.28.1" },
-    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.18.0" },
-    { name = "modelsdotdev", specifier = "==0.*" },
-    { name = "openai", marker = "extra == 'openai'", specifier = ">=2.14.0" },
-    { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'otel'", specifier = ">=1.30" },
-    { name = "opentelemetry-sdk", marker = "extra == 'otel'", specifier = ">=1.30" },
-    { name = "pydantic", specifier = ">=2.13" },
-    { name = "typing-extensions", specifier = ">=4.15.0" },
-    { name = "vercel", marker = "extra == 'vercel'", specifier = ">=0.5.9" },
-]
-provides-extras = ["anthropic", "mcp", "openai", "otel", "vercel"]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "anthropic", specifier = ">=0.83.0" },
-    { name = "async-solipsism", specifier = ">=0.9" },
-    { name = "mcp", specifier = ">=1.18.0" },
-    { name = "mypy", specifier = "~=2.1.0" },
-    { name = "openai", specifier = ">=2.14.0" },
-    { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.43.0" },
-    { name = "opentelemetry-sdk", specifier = ">=1.43.0" },
-    { name = "pytest", specifier = ">=8.0" },
-    { name = "pytest-asyncio", specifier = ">=0.24" },
-    { name = "python-dotenv", specifier = ">=1.2.1" },
-    { name = "rich", specifier = ">=14.2.0" },
-    { name = "ruff", specifier = "~=0.8.0" },
-    { name = "ty", specifier = "~=0.0.37" },
-]
-examples = [
-    { name = "fastapi", specifier = ">=0.136.1" },
-    { name = "temporalio", specifier = ">=1.27.2" },
-    { name = "textual", specifier = ">=8.2.6" },
-    { name = "websockets", specifier = ">=16.0" },
+sdist = { url = "https://files.pythonhosted.org/packages/a1/64/e4fb93545d0bded3a826aa6b9bf7a1154fa67d9f559ad833f59e75778353/ai-0.4.0.tar.gz", hash = "sha256:9b1292d9615b0867591541fc9b82add25a002d78cb6a1c4ed18fb5bc8f217f3f", size = 1181865, upload-time = "2026-07-28T17:56:24.719Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/64/4e70ac7aa8fc6ad586d066cf5d1df853989cb80fd40d12a88172bf26885f/ai-0.4.0-py3-none-any.whl", hash = "sha256:39fb560872c34c43eda400ea1fc6bc4e1488f118f2efb850713677735e31459f", size = 179587, upload-time = "2026-07-28T17:56:23.63Z" },
 ]
 
 [[package]]
@@ -189,7 +156,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "ai", editable = "../../../../" },
+    { name = "ai" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.115.0" },
     { name = "vercel", specifier = ">=0.7.2" },
 ]

--- a/examples/apps/slack_agent/pyproject.toml
+++ b/examples/apps/slack_agent/pyproject.toml
@@ -14,6 +14,3 @@ dev = []
 
 [tool.uv]
 exclude-newer = "2 days"
-
-[tool.uv.sources]
-ai = { path = "../../..", editable = true }

--- a/examples/apps/slack_agent/uv.lock
+++ b/examples/apps/slack_agent/uv.lock
@@ -8,50 +8,17 @@ exclude-newer-span = "P2D"
 
 [[package]]
 name = "ai"
-source = { editable = "../../../" }
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
     { name = "modelsdotdev" },
     { name = "pydantic" },
     { name = "typing-extensions" },
 ]
-
-[package.metadata]
-requires-dist = [
-    { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.83.0" },
-    { name = "httpx", specifier = ">=0.28.1" },
-    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.18.0" },
-    { name = "modelsdotdev", specifier = "==0.*" },
-    { name = "openai", marker = "extra == 'openai'", specifier = ">=2.14.0" },
-    { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'otel'", specifier = ">=1.30" },
-    { name = "opentelemetry-sdk", marker = "extra == 'otel'", specifier = ">=1.30" },
-    { name = "pydantic", specifier = ">=2.13" },
-    { name = "typing-extensions", specifier = ">=4.15.0" },
-    { name = "vercel", marker = "extra == 'vercel'", specifier = ">=0.5.9" },
-]
-provides-extras = ["anthropic", "mcp", "openai", "otel", "vercel"]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "anthropic", specifier = ">=0.83.0" },
-    { name = "async-solipsism", specifier = ">=0.9" },
-    { name = "mcp", specifier = ">=1.18.0" },
-    { name = "mypy", specifier = "~=2.1.0" },
-    { name = "openai", specifier = ">=2.14.0" },
-    { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.43.0" },
-    { name = "opentelemetry-sdk", specifier = ">=1.43.0" },
-    { name = "pytest", specifier = ">=8.0" },
-    { name = "pytest-asyncio", specifier = ">=0.24" },
-    { name = "python-dotenv", specifier = ">=1.2.1" },
-    { name = "rich", specifier = ">=14.2.0" },
-    { name = "ruff", specifier = "~=0.8.0" },
-    { name = "ty", specifier = "~=0.0.37" },
-]
-examples = [
-    { name = "fastapi", specifier = ">=0.136.1" },
-    { name = "temporalio", specifier = ">=1.27.2" },
-    { name = "textual", specifier = ">=8.2.6" },
-    { name = "websockets", specifier = ">=16.0" },
+sdist = { url = "https://files.pythonhosted.org/packages/a1/64/e4fb93545d0bded3a826aa6b9bf7a1154fa67d9f559ad833f59e75778353/ai-0.4.0.tar.gz", hash = "sha256:9b1292d9615b0867591541fc9b82add25a002d78cb6a1c4ed18fb5bc8f217f3f", size = 1181865, upload-time = "2026-07-28T17:56:24.719Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/64/4e70ac7aa8fc6ad586d066cf5d1df853989cb80fd40d12a88172bf26885f/ai-0.4.0-py3-none-any.whl", hash = "sha256:39fb560872c34c43eda400ea1fc6bc4e1488f118f2efb850713677735e31459f", size = 179587, upload-time = "2026-07-28T17:56:23.63Z" },
 ]
 
 [[package]]
@@ -655,7 +622,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "ai", editable = "../../../" },
+    { name = "ai" },
     { name = "aiohttp", specifier = ">=3.10" },
     { name = "slack-bolt", specifier = ">=1.29" },
 ]

--- a/examples/apps/web_agent/backend/pyproject.toml
+++ b/examples/apps/web_agent/backend/pyproject.toml
@@ -5,7 +5,7 @@ description = "Chat demo using Python Vercel AI SDK with FastAPI"
 requires-python = ">=3.12"
 dependencies = [
     "fastapi[standard]>=0.128.1",
-    "ai[vercel]>=0.2.1",
+    "ai[vercel]",
 ]
 
 [dependency-groups]

--- a/examples/apps/web_agent/backend/uv.lock
+++ b/examples/apps/web_agent/backend/uv.lock
@@ -8,7 +8,7 @@ exclude-newer-span = "P2D"
 
 [[package]]
 name = "ai"
-version = "0.3.0"
+version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -16,9 +16,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a6/f3/4c20af62872ebc5c7b444f36627ec2ba93990d884b1f7a19291d07dff54d/ai-0.3.0.tar.gz", hash = "sha256:ff89ec2885d95146713be9afe282f478eaafbff01b6f919b3f03bccb9ba08e22", size = 1188224, upload-time = "2026-07-15T07:31:11.828Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/64/e4fb93545d0bded3a826aa6b9bf7a1154fa67d9f559ad833f59e75778353/ai-0.4.0.tar.gz", hash = "sha256:9b1292d9615b0867591541fc9b82add25a002d78cb6a1c4ed18fb5bc8f217f3f", size = 1181865, upload-time = "2026-07-28T17:56:24.719Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d8/4b/d97e19cba3886cb690ae92b314db2ed714a53acc2d1c858ffd9f2a80340f/ai-0.3.0-py3-none-any.whl", hash = "sha256:5198f14612fef5ed08cc3f84bb723127a653e7a5645ee7ad7ff465e75c95a8e1", size = 170183, upload-time = "2026-07-15T07:31:10.626Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/64/4e70ac7aa8fc6ad586d066cf5d1df853989cb80fd40d12a88172bf26885f/ai-0.4.0-py3-none-any.whl", hash = "sha256:39fb560872c34c43eda400ea1fc6bc4e1488f118f2efb850713677735e31459f", size = 179587, upload-time = "2026-07-28T17:56:23.63Z" },
 ]
 
 [package.optional-dependencies]
@@ -475,7 +475,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "ai", extras = ["vercel"], specifier = ">=0.2.1" },
+    { name = "ai", extras = ["vercel"] },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.128.1" },
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,15 +79,9 @@ dev = [
     "opentelemetry-sdk>=1.43.0",
     "opentelemetry-exporter-otlp-proto-http>=1.43.0",
 ]
-examples = [
-    "fastapi>=0.136.1",
-    "temporalio>=1.27.2",
-    "textual>=8.2.6",
-    "websockets>=16.0",
-]
 
 [tool.uv]
-default-groups = ["dev", "examples"]
+default-groups = ["dev"]
 exclude-newer = "2 days"
 
 [tool.mypy]
@@ -109,10 +103,7 @@ root = ["./src", "./"]
 
 [tool.ty.src]
 exclude = [
-    # depends on the vercel package, which is not part of this project's env
-    "examples/apps/durable_agent_workflows/",
-    # depends on slack-bolt, which is not part of this project's env
-    "examples/apps/slack_agent/",
+    "examples/",
 ]
 
 [tool.pytest.ini_options]

--- a/uv.lock
+++ b/uv.lock
@@ -55,12 +55,6 @@ dev = [
     { name = "ruff" },
     { name = "ty" },
 ]
-examples = [
-    { name = "fastapi" },
-    { name = "temporalio" },
-    { name = "textual" },
-    { name = "websockets" },
-]
 
 [package.metadata]
 requires-dist = [
@@ -92,21 +86,6 @@ dev = [
     { name = "rich", specifier = ">=14.2.0" },
     { name = "ruff", specifier = "~=0.8.0" },
     { name = "ty", specifier = "~=0.0.37" },
-]
-examples = [
-    { name = "fastapi", specifier = ">=0.136.1" },
-    { name = "temporalio", specifier = ">=1.27.2" },
-    { name = "textual", specifier = ">=8.2.6" },
-    { name = "websockets", specifier = ">=16.0" },
-]
-
-[[package]]
-name = "annotated-doc"
-version = "0.0.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
 ]
 
 [[package]]
@@ -473,22 +452,6 @@ wheels = [
 ]
 
 [[package]]
-name = "fastapi"
-version = "0.136.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "annotated-doc" },
-    { name = "pydantic" },
-    { name = "starlette" },
-    { name = "typing-extensions" },
-    { name = "typing-inspection" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5d/45/c130091c2dfa061bbfe3150f2a5091ef1adf149f2a8d2ae769ecaf6e99a2/fastapi-0.136.1.tar.gz", hash = "sha256:7af665ad7acfa0a3baf8983d393b6b471b9da10ede59c60045f49fbc89a0fa7f", size = 397448, upload-time = "2026-04-23T16:49:44.046Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5a/ff/2e4eca3ade2c22fe1dea7043b8ee9dabe47753349eb1b56a202de8af6349/fastapi-0.136.1-py3-none-any.whl", hash = "sha256:a6e9d7eeada96c93a4d69cb03836b44fa34e2854accb7244a1ece36cd4781c3f", size = 117683, upload-time = "2026-04-23T16:49:42.437Z" },
-]
-
-[[package]]
 name = "googleapis-common-protos"
 version = "1.75.0"
 source = { registry = "https://pypi.org/simple" }
@@ -720,18 +683,6 @@ wheels = [
 ]
 
 [[package]]
-name = "linkify-it-py"
-version = "2.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "uc-micro-py" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/2e/c9/06ea13676ef354f0af6169587ae292d3e2406e212876a413bf9eece4eb23/linkify_it_py-2.1.0.tar.gz", hash = "sha256:43360231720999c10e9328dc3691160e27a718e280673d444c38d7d3aaa3b98b", size = 29158, upload-time = "2026-03-01T07:48:47.683Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b4/de/88b3be5c31b22333b3ca2f6ff1de4e863d8fe45aaea7485f591970ec1d3e/linkify_it_py-2.1.0-py3-none-any.whl", hash = "sha256:0d252c1594ecba2ecedc444053db5d3a9b7ec1b0dd929c8f1d74dce89f86c05e", size = 19878, upload-time = "2026-03-01T07:48:46.098Z" },
-]
-
-[[package]]
 name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -741,11 +692,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
-]
-
-[package.optional-dependencies]
-linkify = [
-    { name = "linkify-it-py" },
 ]
 
 [[package]]
@@ -771,18 +717,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/38/83/d1efe7c2980d8a3afa476f4e3d42d53dd54c0ab94c27bee5d755b45c8b73/mcp-1.27.1.tar.gz", hash = "sha256:0f47e1820f8f8f941466b39749eb1d1839a04caddca2bc60e9d46e8a99914924", size = 608458, upload-time = "2026-05-08T16:50:12.601Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/73/42d9596facebdb533b7f0b86c1b0364ef350d1f8ba78b1052e8a58b48b65/mcp-1.27.1-py3-none-any.whl", hash = "sha256:1af3c4203b329430fde7a87b4fcb6392a041f5cb851fd68fc674016ab4e7c06f", size = 216260, upload-time = "2026-05-08T16:50:10.547Z" },
-]
-
-[[package]]
-name = "mdit-py-plugins"
-version = "0.6.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "markdown-it-py" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/59/fc/f8d0863f8862f25602c0404d75568e89fb6b4109804645e5cdfb1be5cf56/mdit_py_plugins-0.6.1.tar.gz", hash = "sha256:a2bca0f039f39dbd35fb74ae1b5f998608c437463371f0ff7f49a19a17a114d0", size = 56114, upload-time = "2026-05-13T09:03:38.91Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a5/69/6da5581c6a7fede7dc261bf4e67d6adca4196f176b43288b55b3db395b6e/mdit_py_plugins-0.6.1-py3-none-any.whl", hash = "sha256:214c82fb2ac524472ab6a5bcab1de80f73b50443e187f401bfd77efbc7c6481d", size = 66663, upload-time = "2026-05-13T09:03:37.76Z" },
 ]
 
 [[package]]
@@ -854,18 +788,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
-]
-
-[[package]]
-name = "nexus-rpc"
-version = "1.4.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/35/d5/cd1ffb202b76ebc1b33c1332a3416e55a39929006982adc2b1eb069aaa9b/nexus_rpc-1.4.0.tar.gz", hash = "sha256:3b8b373d4865671789cc43623e3dc0bcbf192562e40e13727e17f1c149050fba", size = 82367, upload-time = "2026-02-25T22:01:34.053Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/11/52/6327a5f4fda01207205038a106a99848a41c83e933cd23ea2cab3d2ebc6c/nexus_rpc-1.4.0-py3-none-any.whl", hash = "sha256:14c953d3519113f8ccec533a9efdb6b10c28afef75d11cdd6d422640c40b3a49", size = 29645, upload-time = "2026-02-25T22:01:33.122Z" },
 ]
 
 [[package]]
@@ -984,15 +906,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fa/36/e27608899f9b8d4dff0617b2d9ab17ca5608956ca44461ac14ac48b44015/pathspec-1.0.4.tar.gz", hash = "sha256:0210e2ae8a21a9137c0d470578cb0e595af87edaa6ebf12ff176f14a02e0e645", size = 131200, upload-time = "2026-01-27T03:59:46.938Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/3c/2c197d226f9ea224a9ab8d197933f9da0ae0aac5b6e0f884e2b8d9c8e9f7/pathspec-1.0.4-py3-none-any.whl", hash = "sha256:fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723", size = 55206, upload-time = "2026-01-27T03:59:45.137Z" },
-]
-
-[[package]]
-name = "platformdirs"
-version = "4.9.6"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9f/4a/0883b8e3802965322523f0b200ecf33d31f10991d0401162f4b23c698b42/platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a", size = 29400, upload-time = "2026-04-09T00:04:10.812Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917", size = 21348, upload-time = "2026-04-09T00:04:09.463Z" },
 ]
 
 [[package]]
@@ -1402,42 +1315,6 @@ wheels = [
 ]
 
 [[package]]
-name = "temporalio"
-version = "1.27.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "nexus-rpc" },
-    { name = "protobuf" },
-    { name = "types-protobuf" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ca/62/2bc1a9ad29382a3a99f088907ef2024a94420cfef340be1b33026c632828/temporalio-1.27.2.tar.gz", hash = "sha256:633bf2379492f3db1e887d1e64fdac00d9c2ddc3e9382b831d5af68256912e92", size = 2503041, upload-time = "2026-05-14T02:17:57.565Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/64/85/9da14f9fbdfae95435d29353bb1c55891581ad6b23c86ca56e72d83035ed/temporalio-1.27.2-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:860f706380faafec8f183f9194d0883c8033a4211c5d19c2c962c45b06cf99e9", size = 14602829, upload-time = "2026-05-14T02:17:45.624Z" },
-    { url = "https://files.pythonhosted.org/packages/24/51/b7437991e71eea082dc53222da11f064974917cd59063ba57e13e5895fbc/temporalio-1.27.2-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:a8dc0c680e351f3132809861888d8326dbd5030dd4e570663597e7d4768d9502", size = 13997680, upload-time = "2026-05-14T02:17:53.968Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/5d/358065040e6f0cedbf669acd333622999eec737ff868ca7829d727b77746/temporalio-1.27.2-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:805f3de4d193dec52e040e41dbfc9ab44be0206d2e81142ceefaf7b7208058d1", size = 14252199, upload-time = "2026-05-14T02:17:36.972Z" },
-    { url = "https://files.pythonhosted.org/packages/72/8a/85d2eab07c3e23fc1124203e76857c69ab9b22d8ccebad0835e294edb754/temporalio-1.27.2-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5bc996cb501b8a918f50037ccee6facb05bb70984acada4c2a3e01f5e7957a38", size = 14779945, upload-time = "2026-05-14T02:18:05.513Z" },
-    { url = "https://files.pythonhosted.org/packages/67/81/c9b08609e2a92ecf62c97c59cabfa0608337c8d5cc9941eed5d9a7778840/temporalio-1.27.2-cp310-abi3-win_amd64.whl", hash = "sha256:62a84ae9a60c17932971e4ca3b0f3cd6f32f173b8183e759989376503fb95af6", size = 14981897, upload-time = "2026-05-14T02:17:27.333Z" },
-]
-
-[[package]]
-name = "textual"
-version = "8.2.6"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "markdown-it-py", extra = ["linkify"] },
-    { name = "mdit-py-plugins" },
-    { name = "platformdirs" },
-    { name = "pygments" },
-    { name = "rich" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/1c/b3/b62658f6cf808d28e4d16a07509728a7b17824f55a6d3533f017fd4566b0/textual-8.2.6.tar.gz", hash = "sha256:cef3714498a120a99278b98d4c165c278844e73db50f1db039aaabd89f2d1b63", size = 1856990, upload-time = "2026-05-13T09:56:12.281Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b8/b4/c2b876f445e52522824cb900f2c7db3a7c24f89d20449ef278b4195d0ecb/textual-8.2.6-py3-none-any.whl", hash = "sha256:17c92bec7ff1617bd7db2a3d9734b0c3b7d2c274c67d5eba94371ea2f99a63fd", size = 729855, upload-time = "2026-05-13T09:56:14.687Z" },
-]
-
-[[package]]
 name = "tqdm"
 version = "4.67.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1475,15 +1352,6 @@ wheels = [
 ]
 
 [[package]]
-name = "types-protobuf"
-version = "6.32.1.20260221"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5f/e2/9aa4a3b2469508bd7b4e2ae11cbedaf419222a09a1b94daffcd5efca4023/types_protobuf-6.32.1.20260221.tar.gz", hash = "sha256:6d5fb060a616bfb076cbb61b4b3c3969f5fc8bec5810f9a2f7e648ee5cbcbf6e", size = 64408, upload-time = "2026-02-21T03:55:13.916Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2e/e8/1fd38926f9cf031188fbc5a96694203ea6f24b0e34bd64a225ec6f6291ba/types_protobuf-6.32.1.20260221-py3-none-any.whl", hash = "sha256:da7cdd947975964a93c30bfbcc2c6841ee646b318d3816b033adc2c4eb6448e4", size = 77956, upload-time = "2026-02-21T03:55:12.894Z" },
-]
-
-[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1502,15 +1370,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
-]
-
-[[package]]
-name = "uc-micro-py"
-version = "2.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/78/67/9a363818028526e2d4579334460df777115bdec1bb77c08f9db88f6389f2/uc_micro_py-2.0.0.tar.gz", hash = "sha256:c53691e495c8db60e16ffc4861a35469b0ba0821fe409a8a7a0a71864d33a811", size = 6611, upload-time = "2026-03-01T06:31:27.526Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/61/73/d21edf5b204d1467e06500080a50f79d49ef2b997c79123a536d4a17d97c/uc_micro_py-2.0.0-py3-none-any.whl", hash = "sha256:3603a3859af53e5a39bc7677713c78ea6589ff188d70f4fee165db88e22b242c", size = 6383, upload-time = "2026-03-01T06:31:26.257Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Make the examples depend on `ai` and update the lock files to point to
0.4.0.

Drop the examples dep group from the top level, which isn't good for
anything.
