### PR TITLE
Implement testing module with fake model

### DIFF
--- a/src/ai/__init__.py
+++ b/src/ai/__init__.py
@@ -1,4 +1,12 @@
-from . import errors, experimental_telemetry, models, providers, ui, util
+from . import (
+    errors,
+    experimental_telemetry,
+    models,
+    providers,
+    testing,
+    ui,
+    util,
+)
 from .agents import (
     Agent,
     AgentTool,
@@ -196,6 +204,7 @@ __all__ = [
     "resolve_hook",
     "stream",
     "system_message",
+    "testing",
     "text_part",
     "thinking",
     "tool",

--- a/src/ai/testing.py
+++ b/src/ai/testing.py
@@ -1,0 +1,293 @@
+"""Test a model / agent interaction against a script.
+
+:class:`FakeModel` is a drop-in :class:`~ai.models.core.model.Model`
+that replays scripted assistant messages::
+
+    calls = [ai.testing.tool_call(lookup, topic="mars")]
+    model = ai.testing.FakeModel([
+        (ai.user_message("hi"), [
+            ai.assistant_message("checking", *calls),
+            ai.assistant_message("done"),
+        ]),
+    ])
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+from typing import TYPE_CHECKING, Any, Literal, cast
+
+import pydantic
+
+from . import agents, models
+from .types import events
+from .types import messages as messages_
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator, Sequence
+
+    from .models.core import params as params_
+    from .types import tools as tools_
+
+__all__ = ["FakeModel", "fingerprint", "tool_call"]
+
+
+_VOLATILE_MESSAGE_FIELDS = ("id", "turn_id", "usage", "provider_metadata")
+_VOLATILE_PART_FIELDS = (
+    "id",
+    "tool_call_id",
+    "provider_metadata",
+    "model_input",
+    "cached_result",
+)
+
+
+def fingerprint(message: messages_.Message) -> str:
+    """Serialize message and drop volatile fields.
+
+    :class:`FakeModel` uses this to match incoming conversations against script
+    keys; the same dump appears in its error messages.
+    """
+    data = message.model_dump(mode="json")
+    for field in _VOLATILE_MESSAGE_FIELDS:
+        data.pop(field, None)
+    for part in data.get("parts", []):
+        for field in _VOLATILE_PART_FIELDS:
+            part.pop(field, None)
+    return json.dumps(data, sort_keys=True, indent=2)
+
+
+def tool_call(
+    tool: agents.AgentTool | str, **kwargs: Any
+) -> messages_.ToolCallPart:
+    """Build a :class:`ToolCallPart` for a scripted assistant message.
+
+    Validates ``kwargs`` against the tool's signature (when given an
+    :class:`~ai.AgentTool`) and generates a fresh ``tool_call_id``.
+    """
+    if isinstance(tool, str):
+        name = tool
+    else:
+        name = tool.name
+        if tool.validator is not None:
+            tool.validator.model_validate(kwargs)
+    return messages_.ToolCallPart(
+        tool_call_id=messages_.generate_id("call"),
+        tool_name=name,
+        tool_args=json.dumps(kwargs),
+    )
+
+
+@dataclasses.dataclass
+class _Entry:
+    key: messages_.Message
+    key_fingerprint: str
+    responses: list[messages_.Message]
+    played: int = 0
+
+    @property
+    def exhausted(self) -> bool:
+        return self.played >= len(self.responses)
+
+
+type _Script = Sequence[
+    tuple[
+        messages_.Message,
+        messages_.Message | Sequence[messages_.Message],
+    ]
+]
+
+
+def _parse_script(
+    script: _Script,
+) -> tuple[list[_Entry], dict[str, str]]:
+    """Validate the script; return entries and a tool_call_id -> name map."""
+    entries: list[_Entry] = []
+    tool_names: dict[str, str] = {}
+    for index, (key, value) in enumerate(script):
+        responses = (
+            [value] if isinstance(value, messages_.Message) else list(value)
+        )
+        where = f"script entry {index} ({key.text[:60]!r})"
+        if not responses:
+            raise ValueError(f"{where}: no response messages")
+        for position, message in enumerate(responses):
+            if message.role != "assistant":
+                raise ValueError(
+                    f"{where}: response {position} has role "
+                    f"{message.role!r}; scripted responses must be "
+                    "assistant messages"
+                )
+            is_last = position == len(responses) - 1
+            if not is_last and not message.tool_calls:
+                raise ValueError(
+                    f"{where}: response {position} has no tool calls, so "
+                    "the turn ends there and later responses can never "
+                    "play"
+                )
+            for part in message.tool_calls:
+                if part.tool_call_id in tool_names:
+                    raise ValueError(
+                        f"{where}: duplicate tool_call_id "
+                        f"{part.tool_call_id!r}; build each call with its "
+                        "own ai.testing.tool_call(...)"
+                    )
+                tool_names[part.tool_call_id] = part.tool_name
+        entries.append(
+            _Entry(
+                key=key,
+                key_fingerprint=fingerprint(key),
+                responses=responses,
+            )
+        )
+    return entries, tool_names
+
+
+class _FakeProvider(models.Provider):
+    """Provider backing :class:`FakeModel`; replays the script."""
+
+    provider_class_id: Literal["testing-fake-model"] = "testing-fake-model"
+    name: str = "fake"
+    default_base_url: str = "http://fake.invalid"
+
+    _entries: list[_Entry] = pydantic.PrivateAttr(default_factory=list)
+    _tool_names: dict[str, str] = pydantic.PrivateAttr(default_factory=dict)
+    _pending: dict[frozenset[str], _Entry] = pydantic.PrivateAttr(
+        default_factory=dict
+    )
+    _calls: list[list[messages_.Message]] = pydantic.PrivateAttr(
+        default_factory=list
+    )
+
+    async def list_models(self) -> list[str]:
+        return []
+
+    def stream(
+        self,
+        model: models.Model,
+        messages: list[messages_.Message],
+        *,
+        tools: Sequence[tools_.Tool] | None = None,
+        output_type: type[pydantic.BaseModel] | None = None,
+        params: params_.InferenceRequestParams | None = None,
+    ) -> AsyncGenerator[events.Event]:
+        response = self._next_response(messages)
+        return events._replay_message_events(response)
+
+    async def generate(
+        self,
+        model: models.Model,
+        messages: list[messages_.Message],
+        params: params_.GenerateParams,
+    ) -> messages_.Message:
+        return self._next_response(messages)
+
+    def _next_response(
+        self, messages: list[messages_.Message]
+    ) -> messages_.Message:
+        self._calls.append([m.model_copy(deep=True) for m in messages])
+        if not messages:
+            raise AssertionError("FakeModel was called with no messages")
+        last = messages[-1]
+
+        # middle of a turn: answer tool calls with a tool message,
+        # route by tool_call_id.
+        results = last.tool_results
+        if results:
+            ids = frozenset(part.tool_call_id for part in results)
+            entry = self._pending.pop(ids, None)
+            if entry is None:
+                raise AssertionError(self._mismatched_results_error(results))
+            return self._play(entry)
+
+        # start of a turn: match the injected message against the keys.
+        key_fingerprint = fingerprint(last)
+        for entry in self._entries:
+            if entry.played == 0 and entry.key_fingerprint == key_fingerprint:
+                return self._play(entry)
+        raise AssertionError(self._no_entry_error(key_fingerprint))
+
+    def _play(self, entry: _Entry) -> messages_.Message:
+        if entry.exhausted:
+            raise AssertionError(
+                f"FakeModel: entry {entry.key.text[:60]!r} already played "
+                f"all {len(entry.responses)} scripted messages, but the "
+                "model was called again in that conversation"
+            )
+        message = entry.responses[entry.played]
+        entry.played += 1
+        ids = frozenset(part.tool_call_id for part in message.tool_calls)
+        if ids:
+            self._pending[ids] = entry
+        return message
+
+    def _describe(self, ids: frozenset[str]) -> str:
+        return ", ".join(
+            f"{self._tool_names.get(i, '?')}#{i}" for i in sorted(ids)
+        )
+
+    def _mismatched_results_error(
+        self, results: Sequence[messages_.ToolResultPart]
+    ) -> str:
+        got = ", ".join(
+            f"{part.tool_name}#{part.tool_call_id}"
+            for part in sorted(results, key=lambda p: p.tool_call_id)
+        )
+        expected = [self._describe(ids) for ids in self._pending] or [
+            "(none pending)"
+        ]
+        return (
+            "FakeModel: got tool results answering [{got}], but the "
+            "pending scripted tool calls are: {expected}".format(
+                got=got, expected="; ".join(expected)
+            )
+        )
+
+    def _no_entry_error(self, key_fingerprint: str) -> str:
+        unused = [
+            entry.key_fingerprint
+            for entry in self._entries
+            if entry.played == 0
+        ]
+        return (
+            "FakeModel: no scripted entry matches the last message.\n"
+            f"Got:\n{key_fingerprint}\n"
+            "Unused keys:\n" + ("\n".join(unused) if unused else "(none)")
+        )
+
+
+class FakeModel(models.Model):
+    """A model that replays a script instead of calling a provider.
+
+    ``script`` is a sequence of ``(input message, response(s))`` pairs.
+    """
+
+    def __init__(
+        self,
+        script: _Script,
+        *,
+        id: str = "fake-model",
+    ) -> None:
+        provider = _FakeProvider()
+        provider._entries, provider._tool_names = _parse_script(script)
+        super().__init__(id=id, provider=provider)
+
+    @property
+    def _fake(self) -> _FakeProvider:
+        return cast("_FakeProvider", self.provider)
+
+    @property
+    def calls(self) -> list[list[messages_.Message]]:
+        """The exact input messages of every model call, in call order."""
+        return self._fake._calls
+
+    @property
+    def unused(self) -> list[messages_.Message]:
+        """Keys of entries with scripted messages that never played.
+
+        A finished test normally asserts ``not model.unused``.
+        """
+        return [
+            entry.key for entry in self._fake._entries if not entry.exhausted
+        ]

--- a/src/ai/testing.py
+++ b/src/ai/testing.py
@@ -1,15 +1,21 @@
-"""Test a model / agent interaction against a script.
+"""Test a model / agent interaction against scripted conversations.
 
-:class:`FakeModel` is a drop-in :class:`~ai.models.core.model.Model`
-that replays scripted assistant messages::
+A script is a plain list of messages. :class:`FakeModel` is a drop-in
+:class:`~ai.Model` that replays it::
 
-    calls = [ai.testing.tool_call(lookup, topic="mars")]
     model = ai.testing.FakeModel([
-        (ai.user_message("hi"), [
-            ai.assistant_message("checking", *calls),
-            ai.assistant_message("done"),
-        ]),
+        ai.user_message("hi"),
+        ai.assistant_message(
+            "checking", ai.testing.tool_call(lookup, topic="mars")
+        ),
+        ai.assistant_message("done"),
     ])
+
+* tool messages may be left out of a script.
+* include a tool message ``ai.tool_message(...)`` to additionally assert
+  the exact results.
+* unscripted system messages are ignored, so system prompt doesn't need
+  to appear in the script.
 """
 
 from __future__ import annotations
@@ -36,7 +42,6 @@ __all__ = ["FakeModel", "fingerprint", "tool_call"]
 _VOLATILE_MESSAGE_FIELDS = ("id", "turn_id", "usage", "provider_metadata")
 _VOLATILE_PART_FIELDS = (
     "id",
-    "tool_call_id",
     "provider_metadata",
     "model_input",
     "cached_result",
@@ -44,22 +49,26 @@ _VOLATILE_PART_FIELDS = (
 
 
 def fingerprint(message: messages_.Message) -> str:
-    """Serialize message and drop volatile fields.
+    """Serialize a message, dropping volatile fields.
 
-    :class:`FakeModel` uses this to match incoming conversations against script
-    keys; the same dump appears in its error messages.
+    :class:`FakeModel` compares fingerprints to match incoming
+    conversations against scripts.
     """
     data = message.model_dump(mode="json")
     for field in _VOLATILE_MESSAGE_FIELDS:
         data.pop(field, None)
-    for part in data.get("parts", []):
+    parts = data.get("parts", [])
+    for part in parts:
         for field in _VOLATILE_PART_FIELDS:
             part.pop(field, None)
+    if data.get("role") == "tool":
+        # parallel tools finish in arbitrary order
+        parts.sort(key=lambda part: part.get("tool_call_id", ""))
     return json.dumps(data, sort_keys=True, indent=2)
 
 
 def tool_call(
-    tool: agents.AgentTool | str, **kwargs: Any
+    tool: agents.AgentTool | str, /, **kwargs: Any
 ) -> messages_.ToolCallPart:
     """Build a :class:`ToolCallPart` for a scripted assistant message.
 
@@ -80,85 +89,149 @@ def tool_call(
 
 
 @dataclasses.dataclass
-class _Entry:
-    key: messages_.Message
-    key_fingerprint: str
-    responses: list[messages_.Message]
-    played: int = 0
+class _Script:
+    messages: list[messages_.Message]
+    fingerprints: list[str]
+    played: set[int] = dataclasses.field(default_factory=set)
 
-    @property
-    def exhausted(self) -> bool:
-        return self.played >= len(self.responses)
+    def label(self) -> str:
+        return f"script starting with {self.messages[0].text[:60]!r}"
 
 
-type _Script = Sequence[
-    tuple[
-        messages_.Message,
-        messages_.Message | Sequence[messages_.Message],
-    ]
-]
+@dataclasses.dataclass
+class _NoMatch:
+    matched: int  # incoming messages matched before giving up
+    reason: str
 
 
-def _parse_script(
-    script: _Script,
-) -> tuple[list[_Entry], dict[str, str]]:
-    """Validate the script; return entries and a tool_call_id -> name map."""
-    entries: list[_Entry] = []
-    tool_names: dict[str, str] = {}
-    for index, (key, value) in enumerate(script):
-        responses = (
-            [value] if isinstance(value, messages_.Message) else list(value)
-        )
-        where = f"script entry {index} ({key.text[:60]!r})"
-        if not responses:
-            raise ValueError(f"{where}: no response messages")
-        for position, message in enumerate(responses):
-            if message.role != "assistant":
-                raise ValueError(
-                    f"{where}: response {position} has role "
-                    f"{message.role!r}; scripted responses must be "
-                    "assistant messages"
-                )
-            is_last = position == len(responses) - 1
-            if not is_last and not message.tool_calls:
-                raise ValueError(
-                    f"{where}: response {position} has no tool calls, so "
-                    "the turn ends there and later responses can never "
-                    "play"
-                )
+def _parse_scripts(
+    scripts: Sequence[Sequence[messages_.Message]],
+) -> list[_Script]:
+    parsed: list[_Script] = []
+    seen_call_ids: set[str] = set()
+    for index, messages in enumerate(scripts):
+        where = f"script {index}"
+        messages = list(messages)
+        if not messages:
+            raise ValueError(f"{where}: empty script")
+        if not any(m.role == "assistant" for m in messages):
+            raise ValueError(f"{where}: no assistant messages to play")
+        for position, message in enumerate(messages):
             for part in message.tool_calls:
-                if part.tool_call_id in tool_names:
+                if part.tool_call_id in seen_call_ids:
                     raise ValueError(
                         f"{where}: duplicate tool_call_id "
                         f"{part.tool_call_id!r}; build each call with its "
                         "own ai.testing.tool_call(...)"
                     )
-                tool_names[part.tool_call_id] = part.tool_name
-        entries.append(
-            _Entry(
-                key=key,
-                key_fingerprint=fingerprint(key),
-                responses=responses,
+                seen_call_ids.add(part.tool_call_id)
+            if (
+                position > 0
+                and message.role == "assistant"
+                and messages[position - 1].role == "assistant"
+                and not messages[position - 1].tool_calls
+            ):
+                raise ValueError(
+                    f"{where}: message {position - 1} is an assistant "
+                    "message with no tool calls, so the turn ends there "
+                    f"and the assistant message {position} can never play"
+                )
+        parsed.append(
+            _Script(
+                messages=messages,
+                fingerprints=[fingerprint(m) for m in messages],
             )
         )
-    return entries, tool_names
+    return parsed
+
+
+def _walk(
+    script: _Script,
+    got: Sequence[messages_.Message],
+    got_fingerprints: Sequence[str],
+) -> int | _NoMatch:
+    """Match an incoming conversation against a script.
+
+    Returns the index of the next scripted message to play, or a
+    :class:`_NoMatch` explaining where the conversation diverges.
+    """
+    expected = script.messages
+    at = 0  # index into expected
+    matched = 0
+    pending: set[str] = set()  # scripted tool calls awaiting results
+    for position, (message, print_) in enumerate(
+        zip(got, got_fingerprints, strict=True)
+    ):
+        if at < len(expected) and script.fingerprints[at] == print_:
+            if message.role == "tool":
+                pending -= {p.tool_call_id for p in message.tool_results}
+            pending |= {p.tool_call_id for p in expected[at].tool_calls}
+            at += 1
+            matched += 1
+        elif message.role == "tool":
+            # unscripted tool message: results are not asserted, but they
+            # must answer tool calls this script played.
+            ids = {p.tool_call_id for p in message.tool_results}
+            if not ids <= pending:
+                return _NoMatch(
+                    matched,
+                    f"message {position} answers tool calls "
+                    f"{sorted(ids - pending)} that this script never made",
+                )
+            pending -= ids
+        elif message.role == "system":
+            continue  # e.g. an agent's system prompt
+        elif at < len(expected):
+            return _NoMatch(
+                matched,
+                f"message {position} does not match.\n"
+                f"expected:\n{script.fingerprints[at]}\n"
+                f"got:\n{print_}",
+            )
+        else:
+            return _NoMatch(
+                matched, f"the script ended before message {position}"
+            )
+    if at >= len(expected):
+        return _NoMatch(
+            matched,
+            "all scripted messages played, but the model was called again",
+        )
+    nxt = expected[at]
+    if nxt.role != "assistant":
+        return _NoMatch(
+            matched,
+            f"the next scripted message has role {nxt.role!r} and nothing "
+            f"in the conversation matches it:\n{script.fingerprints[at]}",
+        )
+    if pending:
+        return _NoMatch(
+            matched,
+            f"scripted tool calls {sorted(pending)} have no results yet, "
+            f"so the next assistant message cannot play",
+        )
+    return at
 
 
 class _FakeProvider(models.Provider):
-    """Provider backing :class:`FakeModel`; replays the script."""
+    """Provider backing :class:`FakeModel`; replays the scripts."""
 
     provider_class_id: Literal["testing-fake-model"] = "testing-fake-model"
     name: str = "fake"
     default_base_url: str = "http://fake.invalid"
 
-    _entries: list[_Entry] = pydantic.PrivateAttr(default_factory=list)
-    _tool_names: dict[str, str] = pydantic.PrivateAttr(default_factory=dict)
-    _pending: dict[frozenset[str], _Entry] = pydantic.PrivateAttr(
-        default_factory=dict
-    )
+    _scripts: list[_Script] = pydantic.PrivateAttr(default_factory=list)
     _calls: list[list[messages_.Message]] = pydantic.PrivateAttr(
         default_factory=list
     )
+
+    def __init__(
+        self,
+        scripts: Sequence[Sequence[messages_.Message]] = (),
+        **data: Any,
+    ) -> None:
+        super().__init__(**data)
+        self._scripts = _parse_scripts(scripts)
 
     async def list_models(self) -> list[str]:
         return []
@@ -189,89 +262,45 @@ class _FakeProvider(models.Provider):
         self._calls.append([m.model_copy(deep=True) for m in messages])
         if not messages:
             raise AssertionError("FakeModel was called with no messages")
-        last = messages[-1]
+        fingerprints = [fingerprint(m) for m in messages]
+        failures: list[tuple[_Script, _NoMatch]] = []
+        for script in self._scripts:
+            result = _walk(script, messages, fingerprints)
+            if isinstance(result, int):
+                script.played.add(result)
+                return script.messages[result]
+            failures.append((script, result))
+        raise AssertionError(self._no_match_error(fingerprints, failures))
 
-        # middle of a turn: answer tool calls with a tool message,
-        # route by tool_call_id.
-        results = last.tool_results
-        if results:
-            ids = frozenset(part.tool_call_id for part in results)
-            entry = self._pending.pop(ids, None)
-            if entry is None:
-                raise AssertionError(self._mismatched_results_error(results))
-            return self._play(entry)
-
-        # start of a turn: match the injected message against the keys.
-        key_fingerprint = fingerprint(last)
-        for entry in self._entries:
-            if entry.played == 0 and entry.key_fingerprint == key_fingerprint:
-                return self._play(entry)
-        raise AssertionError(self._no_entry_error(key_fingerprint))
-
-    def _play(self, entry: _Entry) -> messages_.Message:
-        if entry.exhausted:
-            raise AssertionError(
-                f"FakeModel: entry {entry.key.text[:60]!r} already played "
-                f"all {len(entry.responses)} scripted messages, but the "
-                "model was called again in that conversation"
-            )
-        message = entry.responses[entry.played]
-        entry.played += 1
-        ids = frozenset(part.tool_call_id for part in message.tool_calls)
-        if ids:
-            self._pending[ids] = entry
-        return message
-
-    def _describe(self, ids: frozenset[str]) -> str:
-        return ", ".join(
-            f"{self._tool_names.get(i, '?')}#{i}" for i in sorted(ids)
-        )
-
-    def _mismatched_results_error(
-        self, results: Sequence[messages_.ToolResultPart]
+    def _no_match_error(
+        self,
+        fingerprints: list[str],
+        failures: list[tuple[_Script, _NoMatch]],
     ) -> str:
-        got = ", ".join(
-            f"{part.tool_name}#{part.tool_call_id}"
-            for part in sorted(results, key=lambda p: p.tool_call_id)
-        )
-        expected = [self._describe(ids) for ids in self._pending] or [
-            "(none pending)"
+        lines = [
+            "FakeModel: no script continues this conversation.",
+            f"The model was called with {len(fingerprints)} message(s); "
+            "the last one:",
+            fingerprints[-1],
         ]
-        return (
-            "FakeModel: got tool results answering [{got}], but the "
-            "pending scripted tool calls are: {expected}".format(
-                got=got, expected="; ".join(expected)
+        if failures:
+            script, no_match = max(failures, key=lambda f: f[1].matched)
+            lines.append(
+                f"Closest is the {script.label()} "
+                f"(matched {no_match.matched} message(s)): {no_match.reason}"
             )
-        )
-
-    def _no_entry_error(self, key_fingerprint: str) -> str:
-        unused = [
-            entry.key_fingerprint
-            for entry in self._entries
-            if entry.played == 0
-        ]
-        return (
-            "FakeModel: no scripted entry matches the last message.\n"
-            f"Got:\n{key_fingerprint}\n"
-            "Unused keys:\n" + ("\n".join(unused) if unused else "(none)")
-        )
+        return "\n".join(lines)
 
 
 class FakeModel(models.Model):
-    """A model that replays a script instead of calling a provider.
-
-    ``script`` is a sequence of ``(input message, response(s))`` pairs.
-    """
+    """A model that replays scripted conversations."""
 
     def __init__(
         self,
-        script: _Script,
-        *,
+        *scripts: Sequence[messages_.Message],
         id: str = "fake-model",
     ) -> None:
-        provider = _FakeProvider()
-        provider._entries, provider._tool_names = _parse_script(script)
-        super().__init__(id=id, provider=provider)
+        super().__init__(id=id, provider=_FakeProvider(scripts=scripts))
 
     @property
     def _fake(self) -> _FakeProvider:
@@ -284,10 +313,13 @@ class FakeModel(models.Model):
 
     @property
     def unused(self) -> list[messages_.Message]:
-        """Keys of entries with scripted messages that never played.
+        """Scripted assistant messages that never played.
 
         A finished test normally asserts ``not model.unused``.
         """
         return [
-            entry.key for entry in self._fake._entries if not entry.exhausted
+            message
+            for script in self._fake._scripts
+            for index, message in enumerate(script.messages)
+            if message.role == "assistant" and index not in script.played
         ]

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -2,7 +2,8 @@
 
 Temporary, deliberately non-trivial examples exercising the scripted
 fake model: parallel tool calls, parallel subagents that themselves
-call tools, plain ai.stream replay, and the failure modes.
+call tools, plain ai.stream replay, multi-turn scripts, and the
+failure modes.
 """
 
 from __future__ import annotations
@@ -13,6 +14,7 @@ import pytest
 
 import ai
 from ai.types import events as events_
+from ai.types import messages as messages_
 
 
 @ai.tool
@@ -31,13 +33,9 @@ async def test_four_parallel_tool_calls() -> None:
     calls = [ai.testing.tool_call(double, word=w) for w in "abcd"]
     model = ai.testing.FakeModel(
         [
-            (
-                ai.user_message("double these: a b c d"),
-                [
-                    ai.assistant_message("doubling", *calls),
-                    ai.assistant_message("done: aa bb cc dd"),
-                ],
-            ),
+            ai.user_message("double these: a b c d"),
+            ai.assistant_message("doubling", *calls),
+            ai.assistant_message("done: aa bb cc dd"),
         ]
     )
 
@@ -86,32 +84,24 @@ async def test_parallel_subagents_with_tool_calls() -> None:
     ]
     model = ai.testing.FakeModel(
         [
-            (
-                ai.user_message("compare mars and venus"),
-                [
-                    ai.assistant_message("researching both", *research_calls),
-                    ai.assistant_message("mars: 2 moons; venus: 0 moons"),
-                ],
+            ai.user_message("compare mars and venus"),
+            ai.assistant_message("researching both", *research_calls),
+            ai.assistant_message("mars: 2 moons; venus: 0 moons"),
+        ],
+        [
+            ai.user_message("research: mars"),
+            ai.assistant_message(
+                "checking", ai.testing.tool_call(moons, planet="mars")
             ),
-            (
-                ai.user_message("research: mars"),
-                [
-                    ai.assistant_message(
-                        "checking", ai.testing.tool_call(moons, planet="mars")
-                    ),
-                    ai.assistant_message("mars has 2 moons"),
-                ],
+            ai.assistant_message("mars has 2 moons"),
+        ],
+        [
+            ai.user_message("research: venus"),
+            ai.assistant_message(
+                "checking", ai.testing.tool_call(moons, planet="venus")
             ),
-            (
-                ai.user_message("research: venus"),
-                [
-                    ai.assistant_message(
-                        "checking", ai.testing.tool_call(moons, planet="venus")
-                    ),
-                    ai.assistant_message("venus has 0 moons"),
-                ],
-            ),
-        ]
+            ai.assistant_message("venus has 0 moons"),
+        ],
     )
     model_ref.append(model)
 
@@ -135,12 +125,65 @@ async def test_parallel_subagents_with_tool_calls() -> None:
     assert not model.unused
 
 
+async def test_multi_turn_with_repeated_user_message() -> None:
+    model = ai.testing.FakeModel(
+        [
+            ai.user_message("hi"),
+            ai.assistant_message("hello"),
+            ai.user_message("hi"),
+            ai.assistant_message("hello again"),
+        ]
+    )
+
+    agent = ai.Agent()
+    history: list[messages_.Message] = [ai.user_message("hi")]
+    async with agent.run(model, history) as stream:
+        async for _ in stream:
+            pass
+    assert stream.messages[-1].text == "hello"
+
+    history = [*stream.messages, ai.user_message("hi")]
+    async with agent.run(model, history) as stream:
+        async for _ in stream:
+            pass
+    assert stream.messages[-1].text == "hello again"
+    assert not model.unused
+
+
+async def test_scripted_tool_message_asserts_results() -> None:
+    # A tool message in the script is an assertion on the actual results.
+    call = ai.testing.tool_call(double, word="hi")
+    script = [
+        ai.user_message("double hi"),
+        ai.assistant_message("on it", call),
+        ai.tool_message(
+            tool_call_id=call.tool_call_id, tool_name="double", result="WRONG"
+        ),
+        ai.assistant_message("done"),
+    ]
+    model = ai.testing.FakeModel(script)
+
+    agent = ai.Agent(tools=[double])
+    # agent.run wraps errors from its task groups in ExceptionGroups
+    expected_error = pytest.RaisesGroup(
+        pytest.RaisesExc(AssertionError, match="WRONG"),
+        flatten_subgroups=True,
+    )
+    with expected_error:
+        async with agent.run(model, [ai.user_message("double hi")]) as stream:
+            async for _ in stream:
+                pass
+
+    assert model.unused  # "done" never played
+
+
 async def test_plain_stream_replays_tool_calls() -> None:
     # ai.stream does not execute tools: a single response, one model call
     call = ai.testing.tool_call(double, word="hi")
     model = ai.testing.FakeModel(
         [
-            (ai.user_message("double hi"), ai.assistant_message("sure", call)),
+            ai.user_message("double hi"),
+            ai.assistant_message("sure", call),
         ]
     )
 
@@ -157,7 +200,8 @@ async def test_plain_stream_replays_tool_calls() -> None:
 async def test_unmatched_input_fails_with_dump() -> None:
     model = ai.testing.FakeModel(
         [
-            (ai.user_message("expected input"), ai.assistant_message("hi")),
+            ai.user_message("expected input"),
+            ai.assistant_message("hi"),
         ]
     )
 
@@ -167,26 +211,22 @@ async def test_unmatched_input_fails_with_dump() -> None:
                 pass
 
     assert "surprise!" in str(err.value)  # what arrived, as a dump
-    assert "expected input" in str(err.value)  # the unused keys
+    assert "expected input" in str(err.value)  # where the script diverges
     assert model.unused  # nothing was consumed
 
 
-async def test_wrong_tool_results_fail_with_ids() -> None:
-    # Script expects both calls answered; drive the follow-up by hand
-    # with only one of them.
+async def test_missing_tool_results_fail_with_ids() -> None:
+    # Script makes two calls; drive the follow-up by hand answering
+    # only one of them.
     calls = [
         ai.testing.tool_call(double, word="a"),
         ai.testing.tool_call(double, word="b"),
     ]
     model = ai.testing.FakeModel(
         [
-            (
-                ai.user_message("go"),
-                [
-                    ai.assistant_message("on it", *calls),
-                    ai.assistant_message("done"),
-                ],
-            ),
+            ai.user_message("go"),
+            ai.assistant_message("on it", *calls),
+            ai.assistant_message("done"),
         ]
     )
 
@@ -208,6 +248,35 @@ async def test_wrong_tool_results_fail_with_ids() -> None:
             async for _ in stream:
                 pass
 
-    message = str(err.value)
-    assert calls[0].tool_call_id in message  # what was answered
-    assert calls[1].tool_call_id in message  # what the script expects
+    # the unanswered call is named
+    assert calls[1].tool_call_id in str(err.value)
+
+
+async def test_foreign_tool_results_fail() -> None:
+    # Results answering a call the script never made are rejected.
+    call = ai.testing.tool_call(double, word="a")
+    model = ai.testing.FakeModel(
+        [
+            ai.user_message("go"),
+            ai.assistant_message("on it", call),
+            ai.assistant_message("done"),
+        ]
+    )
+
+    async with ai.stream(model, [ai.user_message("go")]) as stream:
+        async for _ in stream:
+            pass
+
+    history = [
+        ai.user_message("go"),
+        stream.message,
+        ai.tool_message(
+            tool_call_id="call_bogus", tool_name="double", result="zz"
+        ),
+    ]
+    with pytest.raises(AssertionError) as err:
+        async with ai.stream(model, history) as stream:
+            async for _ in stream:
+                pass
+
+    assert "call_bogus" in str(err.value)

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -1,0 +1,213 @@
+"""Example tests for ai.testing.FakeModel.
+
+Temporary, deliberately non-trivial examples exercising the scripted
+fake model: parallel tool calls, parallel subagents that themselves
+call tools, plain ai.stream replay, and the failure modes.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+import ai
+from ai.types import events as events_
+
+
+@ai.tool
+async def double(word: str) -> str:
+    """Double a word."""
+    return word * 2
+
+
+@ai.tool
+async def moons(planet: str) -> str:
+    """Count a planet's moons."""
+    return {"mars": "2", "venus": "0"}[planet]
+
+
+async def test_four_parallel_tool_calls() -> None:
+    calls = [ai.testing.tool_call(double, word=w) for w in "abcd"]
+    model = ai.testing.FakeModel(
+        [
+            (
+                ai.user_message("double these: a b c d"),
+                [
+                    ai.assistant_message("doubling", *calls),
+                    ai.assistant_message("done: aa bb cc dd"),
+                ],
+            ),
+        ]
+    )
+
+    agent = ai.Agent(tools=[double])
+    async with agent.run(
+        model, [ai.user_message("double these: a b c d")]
+    ) as stream:
+        events = [event async for event in stream]
+
+    messages = stream.messages
+    assert messages[-1].text == "done: aa bb cc dd"
+
+    # every call answered, correlated by the ids tool_call() minted
+    results = {
+        p.tool_call_id: p.result for m in messages for p in m.tool_results
+    }
+    expected = {
+        c.tool_call_id: json.loads(c.tool_args)["word"] * 2 for c in calls
+    }
+    assert results == expected
+
+    # the second model call saw exactly: user, assistant, tool message
+    assert len(model.calls) == 2
+    assert [m.role for m in model.calls[1]] == ["user", "assistant", "tool"]
+    assert not model.unused
+
+    tool_events = [e for e in events if isinstance(e, events_.ToolCallResult)]
+    assert len(tool_events) == 4
+
+
+async def test_parallel_subagents_with_tool_calls() -> None:
+    model_ref: list[ai.Model] = []
+
+    @ai.tool
+    async def research(topic: str) -> ai.SubAgentTool:
+        """Research a topic with a subagent."""
+        inner = ai.Agent(tools=[moons])
+        prompt = ai.user_message(f"research: {topic}")
+        async with inner.run(model_ref[0], [prompt]) as stream:
+            async for event in stream:
+                yield event
+
+    research_calls = [
+        ai.testing.tool_call(research, topic="mars"),
+        ai.testing.tool_call(research, topic="venus"),
+    ]
+    model = ai.testing.FakeModel(
+        [
+            (
+                ai.user_message("compare mars and venus"),
+                [
+                    ai.assistant_message("researching both", *research_calls),
+                    ai.assistant_message("mars: 2 moons; venus: 0 moons"),
+                ],
+            ),
+            (
+                ai.user_message("research: mars"),
+                [
+                    ai.assistant_message(
+                        "checking", ai.testing.tool_call(moons, planet="mars")
+                    ),
+                    ai.assistant_message("mars has 2 moons"),
+                ],
+            ),
+            (
+                ai.user_message("research: venus"),
+                [
+                    ai.assistant_message(
+                        "checking", ai.testing.tool_call(moons, planet="venus")
+                    ),
+                    ai.assistant_message("venus has 0 moons"),
+                ],
+            ),
+        ]
+    )
+    model_ref.append(model)
+
+    agent = ai.Agent(tools=[research])
+    async with agent.run(
+        model, [ai.user_message("compare mars and venus")]
+    ) as stream:
+        [event async for event in stream]
+
+    messages = stream.messages
+    assert messages[-1].text == "mars: 2 moons; venus: 0 moons"
+
+    # each child transcript is attached to the right parent tool call
+    by_id = {p.tool_call_id: p for m in messages for p in m.tool_results}
+    mars, venus = (by_id[c.tool_call_id] for c in research_calls)
+    assert mars.get_model_input() == "mars has 2 moons"
+    assert venus.get_model_input() == "venus has 0 moons"
+
+    # parent: 2 calls; each child: 2 calls
+    assert len(model.calls) == 6
+    assert not model.unused
+
+
+async def test_plain_stream_replays_tool_calls() -> None:
+    # ai.stream does not execute tools: a single response, one model call
+    call = ai.testing.tool_call(double, word="hi")
+    model = ai.testing.FakeModel(
+        [
+            (ai.user_message("double hi"), ai.assistant_message("sure", call)),
+        ]
+    )
+
+    async with ai.stream(model, [ai.user_message("double hi")]) as stream:
+        [event async for event in stream]
+
+    assert stream.message.text == "sure"
+    assert [c.tool_call_id for c in stream.message.tool_calls] == [
+        call.tool_call_id
+    ]
+    assert not model.unused
+
+
+async def test_unmatched_input_fails_with_dump() -> None:
+    model = ai.testing.FakeModel(
+        [
+            (ai.user_message("expected input"), ai.assistant_message("hi")),
+        ]
+    )
+
+    with pytest.raises(AssertionError) as err:
+        async with ai.stream(model, [ai.user_message("surprise!")]) as stream:
+            async for _ in stream:
+                pass
+
+    assert "surprise!" in str(err.value)  # what arrived, as a dump
+    assert "expected input" in str(err.value)  # the unused keys
+    assert model.unused  # nothing was consumed
+
+
+async def test_wrong_tool_results_fail_with_ids() -> None:
+    # Script expects both calls answered; drive the follow-up by hand
+    # with only one of them.
+    calls = [
+        ai.testing.tool_call(double, word="a"),
+        ai.testing.tool_call(double, word="b"),
+    ]
+    model = ai.testing.FakeModel(
+        [
+            (
+                ai.user_message("go"),
+                [
+                    ai.assistant_message("on it", *calls),
+                    ai.assistant_message("done"),
+                ],
+            ),
+        ]
+    )
+
+    async with ai.stream(model, [ai.user_message("go")]) as stream:
+        async for _ in stream:
+            pass
+
+    partial_history = [
+        ai.user_message("go"),
+        stream.message,
+        ai.tool_message(
+            tool_call_id=calls[0].tool_call_id,
+            tool_name="double",
+            result="aa",
+        ),
+    ]
+    with pytest.raises(AssertionError) as err:
+        async with ai.stream(model, partial_history) as stream:
+            async for _ in stream:
+                pass
+
+    message = str(err.value)
+    assert calls[0].tool_call_id in message  # what was answered
+    assert calls[1].tool_call_id in message  # what the script expects


### PR DESCRIPTION
Adds utilities to simplify unit testing.

- `FakeModel` replays a script
- a script is a list of `ai.messages.Message`
- `FakeModel` can take more than one script, if the goal is to test multiple turns / subagents
