### PR TITLE
Make ToolRunner a little more flexible

### DIFF
--- a/src/ai/agents/agent.py
+++ b/src/ai/agents/agent.py
@@ -719,7 +719,7 @@ class BoundToolCall:
                         f"async iterable, not {type(returned).__name__}; "
                         f"declare it with `async def`"
                     )
-            except Exception as exc:
+            except (Exception, asyncio.CancelledError) as exc:
                 return _error_tool_result(
                     exc,
                     tool_call_id=call.tool_call_id,
@@ -846,7 +846,6 @@ class _RestartableToolStream:
 
 class ToolRunner:
     def __init__(self) -> None:
-        self._new_results: list[events_.ToolCallResult] = []
         self._tool_results: list[events_.ToolCallResult] = []
         self._tg_base = util.TaskGroup()
         self._waiter: util.MultiWaiter[events_.ToolCallResult] = (
@@ -864,7 +863,9 @@ class ToolRunner:
     def events(self) -> _RestartableToolStream:
         return _RestartableToolStream(self)
 
-    def schedule(self, tc: ToolCallCallable) -> None:
+    def schedule(
+        self, tc: ToolCallCallable
+    ) -> asyncio.Task[events_.ToolCallResult]:
         """Schedule a tool call (or any callable producing a ToolCallResult).
 
         See :class:`ToolCallCallable` — accepts both :class:`ToolCall` and
@@ -872,8 +873,20 @@ class ToolRunner:
         :class:`ToolCallResult`.  The latter lets you wrap a ``ToolCall``
         in custom logic (e.g. an approval hook await) and still ride the
         runner's merge-and-iterate flow.
+
+        Returns the task.
         """
-        self._waiter.add(self._tg.create_task(tc()))
+        task = self._tg.create_task(tc())
+        self._waiter.add(task)
+        return task
+
+    def discard(self, task: asyncio.Task[events_.ToolCallResult]) -> None:
+        """Discard a task from the ToolRunner.
+
+        Cancel the task and ignore its result.
+        """
+        self._waiter.discard(task)
+        task.cancel()
 
     def add_result(self, res: events_.ToolCallResult) -> None:
         async def _feed() -> events_.ToolCallResult:
@@ -889,8 +902,7 @@ class ToolRunner:
         return None
 
     async def _iterate(self) -> AsyncGenerator[events_.ToolCallResult]:
-        while self._waiter.tasks():
-            t = await self._waiter
+        while t := await self._waiter:
             try:
                 res = t.result()
             except asyncio.CancelledError:

--- a/src/ai/util.py
+++ b/src/ai/util.py
@@ -92,6 +92,8 @@ class MultiWaiter[T]:
         for task in tasks:
             self._tasks.pop(task, None)
             task.remove_done_callback(self._callback)
+            # Queue it up so that a waiter pops out of the loop
+            self._queue.put_nowait(task)
 
     def clear(self) -> None:
         for task in self._tasks:

--- a/src/ai/util.py
+++ b/src/ai/util.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import dataclasses
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 if TYPE_CHECKING:
     from collections.abc import (
@@ -76,7 +76,7 @@ class MultiWaiter[T]:
 
     def __init__(self, *tasks: asyncio.Future[T]) -> None:
         self._queue: asyncio.Queue[asyncio.Future[T]] = asyncio.Queue(0)
-        self._tasks: dict[asyncio.Future[T], None] = {}
+        self._tasks: dict[asyncio.Future[T], Literal[True]] = {}
 
         # We bind this to an attribute so that the bound method is
         # always the same and can be passed to remove_done_callback.
@@ -85,8 +85,13 @@ class MultiWaiter[T]:
 
     def add(self, *tasks: asyncio.Future[T]) -> None:
         for task in tasks:
-            self._tasks[task] = None
+            self._tasks[task] = True
             task.add_done_callback(self._callback)
+
+    def discard(self, *tasks: asyncio.Future[T]) -> None:
+        for task in tasks:
+            self._tasks.pop(task, None)
+            task.remove_done_callback(self._callback)
 
     def clear(self) -> None:
         for task in self._tasks:
@@ -96,12 +101,15 @@ class MultiWaiter[T]:
     def tasks(self) -> Collection[asyncio.Future[T]]:
         return self._tasks.keys()
 
-    async def wait(self) -> asyncio.Future[T]:
-        t = await self._queue.get()
-        self._tasks.pop(t, None)
-        return t
+    async def wait(self) -> asyncio.Future[T] | None:
+        while self._tasks:
+            t = await self._queue.get()
+            # Only return the future if it hasn't been discarded
+            if self._tasks.pop(t, None):
+                return t
+        return None
 
-    def __await__(self) -> Generator[Any, Any, asyncio.Future[T]]:
+    def __await__(self) -> Generator[Any, Any, asyncio.Future[T] | None]:
         return self.wait().__await__()
 
     async def __aenter__(self) -> MultiWaiter[T]:
@@ -271,9 +279,7 @@ async def merge[T](
         mw.add(*[t for t in tasks if t])
 
         top_fired = False
-        while mw.tasks():
-            t = await mw
-
+        while t := await mw:
             idx = tasks.index(t)
             val = t.result()
             if val is _EMPTY:

--- a/tests/agents/test_tools.py
+++ b/tests/agents/test_tools.py
@@ -10,6 +10,7 @@ import pydantic
 import pytest
 
 import ai
+from ai.types import events as events_
 
 # Declaring a tool with a plain `def` is a type error by design; go
 # through an untyped view of the decorator to reach the runtime check.
@@ -91,6 +92,27 @@ async def test_tool_call_with_json_args() -> None:
 # -- ToolCall binds a ToolCallPart to a Tool and returns tool messages ----
 
 
+async def test_tool_runner_discard_cancels_and_omits_task() -> None:
+    """Discarded speculative calls do not produce tool events or messages."""
+    started = asyncio.Event()
+
+    async def speculative() -> events_.ToolCallResult:
+        started.set()
+        await asyncio.Future()
+        return ai.tool_result(tool_call_id="tc-speculative", result="unused")
+
+    async with ai.ToolRunner() as runner:
+        task = runner.schedule(speculative)
+        assert isinstance(task, asyncio.Task)
+        await started.wait()
+        runner.discard(task)
+
+        assert [event async for event in runner.events()] == []
+        assert runner.get_tool_message() is None
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+
 async def test_tool_call_returns_tool_message() -> None:
     @ai.tool
     async def double(x: int) -> int:
@@ -115,6 +137,33 @@ async def test_tool_call_returns_tool_message() -> None:
     assert out == 10
     assert not result.results[0].is_error
     assert not result.results[0].has_model_input
+
+
+async def test_cancelled_tool_call_returns_error_result() -> None:
+    started = asyncio.Event()
+
+    @ai.tool
+    async def wait_forever() -> str:
+        """Wait until cancelled."""
+        started.set()
+        await asyncio.Future()
+        return "unreachable"
+
+    part = ai.messages.ToolCallPart(
+        tool_call_id="tc-cancelled",
+        tool_name="wait_forever",
+        tool_args="{}",
+    )
+    task = asyncio.create_task(
+        ai.agents.BoundToolCall(part=part, tool=wait_forever)()
+    )
+    await started.wait()
+    task.cancel()
+    result = await task
+
+    assert result.results[0].is_error
+    assert "CancelledError" in str(result.results[0].result)
+    assert isinstance(result.exception, asyncio.CancelledError)
 
 
 async def test_tool_call_catches_errors() -> None:

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -192,6 +192,31 @@ async def test_cleanup_with_non_generator_iterable() -> None:
     assert exc_info.group_contains(RuntimeError, match="boom")
 
 
+# -- MultiWaiter -------------------------------------------------------------
+
+
+async def test_empty_multiwaiter_returns_none() -> None:
+    """Waiting with no tracked futures finishes rather than blocking."""
+    assert await util.MultiWaiter[int]() is None
+
+
+async def test_multiwaiter_discard_ignores_completed_future() -> None:
+    """A queued completion from a discarded future is not returned later."""
+    loop = asyncio.get_running_loop()
+    discarded: asyncio.Future[int] = loop.create_future()
+    kept: asyncio.Future[int] = loop.create_future()
+    waiter = util.MultiWaiter(discarded)
+
+    discarded.set_result(1)
+    await asyncio.sleep(0)  # Let its done callback enqueue the future.
+    waiter.discard(discarded)
+    waiter.add(kept)
+    kept.set_result(2)
+
+    assert await waiter is kept
+    assert not waiter.tasks()
+
+
 # -- TaskGroup --------------------------------------------------------------
 
 


### PR DESCRIPTION
`schedule()` now returns the task that the tool is run on, which
allows a caller to cancel it, if desired.
To support this better, BoundToolCall will catch CancelledError and
turn it into an error tool result.

ToolRunner also gets a `discard()` method, which cancels the task and
removes it from the ToolRunner's tracking. This is useful if tools are
launched speculatively, for example.
