### PR TITLE
fix(ui): propagate StreamEnd finish_reason to UI finish event

### DIFF
--- a/src/ai/ui/ai_sdk/outbound_stream.py
+++ b/src/ai/ui/ai_sdk/outbound_stream.py
@@ -50,6 +50,29 @@ def _to_wire_output(snapshot: Any) -> Any:
     return snapshot
 
 
+_FINISH_REASON_TO_UI: dict[str, ui_events.FinishReason] = {
+    "stop": "stop",
+    "length": "length",
+    "content_filter": "content-filter",
+    "tool_call": "tool-calls",
+    "error": "error",
+    "other": "other",
+}
+
+
+def _finish_reason_to_ui(finish_reason: str | None) -> ui_events.FinishReason:
+    """Map an internal finish reason onto the AI SDK UI wire value.
+
+    Internal events use the OpenTelemetry ``gen_ai`` vocabulary
+    (``content_filter``, ``tool_call``) while the UI protocol uses kebab-case
+    (``content-filter``, ``tool-calls``).  Unknown values become ``other``
+    and a missing reason defaults to ``stop``.
+    """
+    if finish_reason is None:
+        return "stop"
+    return _FINISH_REASON_TO_UI.get(finish_reason, "other")
+
+
 class _StreamState:
     """Single-pass state across one ``to_stream()`` call."""
 
@@ -58,6 +81,7 @@ class _StreamState:
         self.emitted_start: bool = False
         self.in_step: bool = False
         self.step_ended: bool = False
+        self.finish_reason: str | None = None
 
         self.started_tool_inputs: set[str] = set()
         self.tool_names: dict[str, str] = {}
@@ -155,6 +179,7 @@ class _StreamState:
 
         match event:
             case events_.StreamEnd():
+                self.finish_reason = event.finish_reason
                 self.step_ended = True
 
             case events_.StreamStart():
@@ -566,7 +591,7 @@ class _StreamState:
         if self.emitted_start:
             events.append(
                 ui_events.UIFinishEvent(
-                    finish_reason="stop",
+                    finish_reason=_finish_reason_to_ui(self.finish_reason),
                     message_metadata=self._latest_assistant_metadata(),
                 )
             )

--- a/tests/ui/ai_sdk/test_outbound_stream.py
+++ b/tests/ui/ai_sdk/test_outbound_stream.py
@@ -263,6 +263,93 @@ async def test_finish_metadata_ignores_empty_messages() -> None:
     assert finish.message_metadata is None
 
 
+async def test_finish_reason_defaults_to_stop() -> None:
+    out = await _collect(
+        [
+            events_.StreamStart(),
+            events_.TextStart(block_id="t1"),
+            events_.TextEnd(block_id="t1"),
+            events_.StreamEnd(),
+        ]
+    )
+
+    finish = next(
+        event for event in out if isinstance(event, ui_events.UIFinishEvent)
+    )
+    assert finish.finish_reason == "stop"
+
+
+async def test_finish_reason_propagates_from_stream_end() -> None:
+    out = await _collect(
+        [
+            events_.StreamStart(),
+            events_.StreamEnd(finish_reason="stop"),
+        ]
+    )
+
+    finish = next(
+        event for event in out if isinstance(event, ui_events.UIFinishEvent)
+    )
+    assert finish.finish_reason == "stop"
+
+
+async def test_finish_reason_maps_content_filter() -> None:
+    out = await _collect(
+        [
+            events_.StreamStart(),
+            events_.StreamEnd(finish_reason="content_filter"),
+        ]
+    )
+
+    finish = next(
+        event for event in out if isinstance(event, ui_events.UIFinishEvent)
+    )
+    assert finish.finish_reason == "content-filter"
+
+
+async def test_finish_reason_maps_tool_call() -> None:
+    out = await _collect(
+        [
+            events_.StreamStart(),
+            events_.StreamEnd(finish_reason="tool_call"),
+        ]
+    )
+
+    finish = next(
+        event for event in out if isinstance(event, ui_events.UIFinishEvent)
+    )
+    assert finish.finish_reason == "tool-calls"
+
+
+async def test_finish_reason_passes_through_length_and_error() -> None:
+    for reason in ("length", "error"):
+        out = await _collect(
+            [
+                events_.StreamStart(),
+                events_.StreamEnd(finish_reason=reason),
+            ]
+        )
+
+        finish = next(
+            event for event in out if isinstance(event, ui_events.UIFinishEvent)
+        )
+        assert finish.finish_reason == reason
+
+
+async def test_finish_reason_maps_unknown_to_other() -> None:
+    out = await _collect(
+        [
+            events_.StreamStart(),
+            events_.StreamEnd(finish_reason="some_provider_reason"),
+        ]
+    )
+
+    finish = next(
+        event for event in out if isinstance(event, ui_events.UIFinishEvent)
+    )
+    assert finish.finish_reason == "other"
+
+
 async def test_tool_call_and_result_emit_terminal_events() -> None:
     """ToolCallResult emits tool input and output events."""
     tool_result_msg = messages_.Message(


### PR DESCRIPTION
## What

The AI SDK UI `finish` event always carries `finishReason: "stop"`, regardless of why the model actually stopped: `_StreamState` discarded `StreamEnd.finish_reason` and `finish()` hardcoded `"stop"`.

## Why

Frontends built on `useChat`/the AI SDK UI message stream branch on `finishReason` — surfacing truncation (`length`), content-filter stops, or recognizing that a turn ended because tools were called (`tool-calls`). With the hardcoded value every run looks like a clean text stop, which breaks that logic.

## How

- Capture `StreamEnd.finish_reason` in `_StreamState`
- Map the internal OpenTelemetry-style vocabulary (`content_filter`, `tool_call`) to the UI wire values (`content-filter`, `tool-calls`); unknown values → `other`, missing → `stop` (preserving current behavior)

## Tests

Added coverage for: default `stop`, `stop` passthrough, `content_filter` → `content-filter`, `tool_call` → `tool-calls`, `length`/`error` passthrough, and unknown → `other`. Full local gate green: ruff format/check, mypy, ty, 692 pytest tests, check-examples.