### PR TITLE
fix(types): detect video media types in FilePart.from_bytes

### DIFF
--- a/src/ai/types/media.py
+++ b/src/ai/types/media.py
@@ -330,3 +330,8 @@ def detect_image_media_type(data: bytes | str) -> str | None:
 def detect_audio_media_type(data: bytes | str) -> str | None:
     """Detect audio format from magic bytes."""
     return detect_media_type(data, AUDIO_SIGNATURES)
+
+
+def detect_video_media_type(data: bytes | str) -> str | None:
+    """Detect video format from magic bytes."""
+    return detect_media_type(data, VIDEO_SIGNATURES)

--- a/src/ai/types/messages.py
+++ b/src/ai/types/messages.py
@@ -143,14 +143,16 @@ class FilePart(pydantic.BaseModel):
     ) -> Self:
         """Create from raw bytes, detecting ``media_type`` via magic bytes.
 
-        Attempts image detection first, then audio.  Raises
+        Attempts image detection first, then audio, then video.  Raises
         :class:`ValueError` if no ``media_type`` is provided and
         detection fails.
         """
         if media_type is None:
-            media_type = media.detect_image_media_type(
-                data
-            ) or media.detect_audio_media_type(data)
+            media_type = (
+                media.detect_image_media_type(data)
+                or media.detect_audio_media_type(data)
+                or media.detect_video_media_type(data)
+            )
         if media_type is None:
             raise ValueError(
                 "Cannot detect media_type from bytes. "

--- a/tests/types/test_media.py
+++ b/tests/types/test_media.py
@@ -12,6 +12,10 @@ _RIFF_WEBP = bytes(
 _RIFF_WAVE = bytes(
     [0x52, 0x49, 0x46, 0x46, 0x00, 0x00, 0x00, 0x00, 0x57, 0x41, 0x56, 0x45]
 )
+_MP4 = bytes(
+    [0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70, 0x69, 0x73, 0x6F, 0x6D]
+)
+_JPEG = bytes([0xFF, 0xD8, 0xFF, 0xE0])
 
 
 def test_data_to_base64_extracts_from_data_url() -> None:
@@ -90,3 +94,16 @@ def test_data_to_base64_str_passthrough() -> None:
     """Standard base-64 string passes through unchanged."""
     standard = "/9j/4AAQSkZJRg=="
     assert media.data_to_base64(standard) == standard
+
+
+def test_detect_video_media_type_mp4() -> None:
+    assert media.detect_video_media_type(_MP4) == "video/mp4"
+
+
+def test_detect_video_media_type_base64() -> None:
+    b64 = base64.b64encode(_MP4).decode()
+    assert media.detect_video_media_type(b64) == "video/mp4"
+
+
+def test_detect_video_media_type_rejects_image() -> None:
+    assert media.detect_video_media_type(_JPEG) is None

--- a/tests/types/test_messages.py
+++ b/tests/types/test_messages.py
@@ -118,6 +118,14 @@ def test_from_bytes_detects_audio() -> None:
     assert fp.media_type == "audio/wav"
 
 
+def test_from_bytes_detects_video() -> None:
+    data = bytes(
+        [0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70, 0x69, 0x73, 0x6F, 0x6D]
+    )
+    fp = messages.FilePart.from_bytes(data)
+    assert fp.media_type == "video/mp4"
+
+
 def test_from_bytes_explicit_overrides() -> None:
     fp = messages.FilePart.from_bytes(b"\x00\x00", media_type="video/mp4")
     assert fp.media_type == "video/mp4"


### PR DESCRIPTION
## What

`FilePart.from_bytes()` could not detect video files: it only checked image and audio signatures, so `file_part(video_bytes)` raised `ValueError` unless you passed `media_type` manually. The `VIDEO_SIGNATURES` table already existed but had no public wrapper.

## Why

Image and audio detection work; video doesn't — a concrete capability gap for attaching video input (e.g. video-capable gateway models) and video round-trips. `ai.file_part(open("clip.mp4", "rb").read())` should just work.

## How

- Add `media.detect_video_media_type()` mirroring the existing image/audio wrappers
- Chain it into `FilePart.from_bytes`: image → audio → video

## Tests

- `detect_video_media_type`: mp4 detection, base64 input, rejects non-video (image)
- `FilePart.from_bytes`: video/mp4 detection

Full local gate green: ruff format/check, mypy, ty, 690 pytest tests, check-examples.

## Known limitation (pre-existing, not changed)

Webm is container-ambiguous — `audio/webm` is checked before `video/webm`, so webm video still reports `audio/webm`. Reordering would regress genuine webm audio detection. Also note `video/quicktime` is shadowed by the mp4 signature's wildcard size byte — both pre-existing table behavior.