### PR TITLE
feat(tools): parameter descriptions via Annotated and docstring Args

### DIFF
--- a/docs/ai-python/content/docs/basics/tools.mdx
+++ b/docs/ai-python/content/docs/basics/tools.mdx
@@ -25,6 +25,35 @@ async def contact_mothership(query: str) -> str:
 The tool name comes from the function name. The model receives the function
 parameters as a JSON schema and the docstring as the tool description.
 
+## Describe parameters
+
+The model chooses tools and fills their arguments based on the parameter
+schema. Give each parameter a description with `Annotated` and pydantic's
+`Field`, or with a Google-style `Args:` section in the docstring:
+
+```python
+from typing import Annotated
+
+import ai
+from pydantic import Field
+
+
+@ai.tool
+async def get_weather(
+    city: Annotated[str, Field(description="City name")],
+    days: Annotated[int, Field(ge=1, le=7, description="Forecast length")],
+) -> str:
+    """Get the weather forecast.
+
+    Args:
+        city: City to forecast for.
+    """
+    return "sunny"
+```
+
+Descriptions from `Field` win when both are present. Parameters without any
+description stay undocumented in the schema.
+
 Function tools will only be automatically executed by the SDK when used
 in the context of the agent. Provider-side tools will always get executed
 by the provider, even when passed to `ai.stream`.

--- a/docs/ai-python/content/docs/reference/ai/tool-decorator.mdx
+++ b/docs/ai-python/content/docs/reference/ai/tool-decorator.mdx
@@ -34,6 +34,35 @@ The function name becomes the tool name. The docstring becomes the tool
 description. The function signature becomes a Pydantic validator and JSON
 schema.
 
+## Parameter descriptions
+
+Parameter descriptions reach the model's schema two ways:
+
+```python
+from typing import Annotated
+
+import ai
+from pydantic import Field
+
+
+@ai.tool
+async def get_weather(
+    city: Annotated[str, Field(description="City name")],
+    days: Annotated[int, Field(ge=1, le=7, description="Forecast length")] = 3,
+) -> str:
+    """Get the weather forecast.
+
+    Args:
+        city: City to forecast for.
+        days: Forecast length in days.
+    """
+    return "sunny"
+```
+
+`Field` metadata always survives into the JSON schema. A Google-style
+`Args:` section fills descriptions for parameters that have no `Field`
+description.
+
 The decorated callable must return an awaitable or an async iterable. Every
 async iterable tool needs an aggregator. Pass `aggregator=` or annotate the
 return type with an `ai.agents.Aggregate` marker, but do not use both.

--- a/src/ai/agents/agent.py
+++ b/src/ai/agents/agent.py
@@ -7,6 +7,7 @@ import contextlib
 import dataclasses
 import inspect
 import json
+import re
 import typing
 from collections.abc import (
     AsyncGenerator,
@@ -452,6 +453,79 @@ def _aggregate_from_return_type(fn: Callable[..., Any]) -> Aggregate | None:
     return matches[0] if matches else None
 
 
+_DOCSTRING_SECTION_RE = re.compile(r"^(Returns|Raises|Yields|Examples?):")
+_DOCSTRING_PARAM_RE = re.compile(
+    r"^(\*{0,2}[A-Za-z_]\w*)(?:\s*\([^)]*\))?\s*:\s*(.*)$"
+)
+
+
+def _param_descriptions_from_docstring(
+    fn: Callable[..., Any],
+) -> dict[str, str]:
+    """Extract parameter descriptions from a Google-style ``Args:`` section.
+
+    Returns a mapping of parameter name to description. Names that are not
+    parameters of ``fn`` are kept; callers decide what to do with them.
+    """
+    doc = inspect.getdoc(fn)
+    if doc is None:
+        return {}
+
+    lines = doc.splitlines()
+    start = next(
+        (
+            i
+            for i, line in enumerate(lines)
+            if line.strip() in ("Args:", "Parameters:")
+        ),
+        None,
+    )
+    if start is None:
+        return {}
+
+    descriptions: dict[str, str] = {}
+    current_name: str | None = None
+    parts: list[str] = []
+
+    def flush() -> None:
+        nonlocal current_name
+        if current_name is not None and parts:
+            descriptions[current_name] = " ".join(parts)
+        current_name = None
+        parts.clear()
+
+    base_indent: int | None = None
+    for raw in lines[start + 1 :]:
+        stripped = raw.strip()
+        if _DOCSTRING_SECTION_RE.match(stripped):
+            flush()
+            break
+        if not stripped:
+            flush()
+            continue
+
+        indent = len(raw) - len(raw.lstrip())
+        if base_indent is None:
+            base_indent = indent
+
+        match = (
+            _DOCSTRING_PARAM_RE.match(stripped)
+            if indent == base_indent
+            else None
+        )
+        if match:
+            flush()
+            current_name = match.group(1).lstrip("*")
+            first = match.group(2).strip()
+            if first:
+                parts.append(first)
+        elif current_name is not None:
+            parts.append(stripped)
+    flush()
+
+    return descriptions
+
+
 Tool = types.tools.Tool
 
 
@@ -579,7 +653,11 @@ def tool[**P, T, R](
 
     def wrap(fn: Any) -> AgentTool:
         sig = inspect.signature(fn)
-        hints = get_type_hints(fn) if hasattr(fn, "__annotations__") else {}
+        hints = (
+            get_type_hints(fn, include_extras=True)
+            if hasattr(fn, "__annotations__")
+            else {}
+        )
 
         fields: dict[str, Any] = {}
         for param_name, param in sig.parameters.items():
@@ -590,6 +668,15 @@ def tool[**P, T, R](
                 fields[param_name] = (param_type, param.default)
 
         validator = pydantic.create_model(f"{fn.__name__}_Args", **fields)
+
+        schema = validator.model_json_schema()
+        docstring_descriptions = _param_descriptions_from_docstring(fn)
+        for param_name, prop in schema.get("properties", {}).items():
+            if (
+                not prop.get("description")
+                and param_name in docstring_descriptions
+            ):
+                prop["description"] = docstring_descriptions[param_name]
 
         annotated_return_type = _return_type_from_callable(fn)
         annotated_aggregate = _aggregate_from_return_type(fn)
@@ -612,7 +699,7 @@ def tool[**P, T, R](
             name=fn.__name__,
             spec=types.tools.ToolSpec(
                 description=inspect.getdoc(fn) or "",
-                params=validator.model_json_schema(),
+                params=schema,
             ),
             require_approval=require_approval,
         )

--- a/tests/agents/test_tools.py
+++ b/tests/agents/test_tools.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import AsyncGenerator, Callable
-from typing import Any, cast
+from typing import Annotated, Any, cast
 
 import pydantic
 import pytest
@@ -501,3 +501,140 @@ def test_to_model_input_with_aggregate_marker_is_rejected() -> None:
         async def t() -> ai.StreamingTextTool:
             """Stream."""
             yield "x"
+
+
+# -- Parameter descriptions -------------------------------------------------
+
+
+def test_annotated_field_description_lands_in_schema() -> None:
+    @ai.tool
+    async def get_weather(
+        city: Annotated[str, pydantic.Field(description="City name")],
+        days: Annotated[
+            int, pydantic.Field(ge=1, le=7, description="Forecast length")
+        ],
+    ) -> str:
+        """Get the weather."""
+        return "sunny"
+
+    props = _schema(get_weather)["properties"]
+    assert props["city"]["description"] == "City name"
+    assert props["days"]["description"] == "Forecast length"
+    assert props["days"]["minimum"] == 1
+    assert props["days"]["maximum"] == 7
+
+
+def test_annotated_inside_optional_is_not_stripped() -> None:
+    @ai.tool
+    async def search(
+        query: str,
+        limit: Annotated[int, pydantic.Field(ge=1, description="Max results")]
+        | None = None,
+    ) -> str:
+        """Search."""
+        return query
+
+    # For `X | None` unions the metadata lives on the non-null branch.
+    prop = _schema(search)["properties"]["limit"]
+    branch = next(b for b in prop["anyOf"] if b.get("type") == "integer")
+    assert branch["description"] == "Max results"
+    assert branch["minimum"] == 1
+
+
+def test_docstring_args_section_fills_descriptions() -> None:
+    @ai.tool
+    async def deliver(
+        address: str,
+        fragile: bool,
+        note: str = "",
+    ) -> str:
+        """Deliver a package.
+
+        Args:
+            address: Street address to ship to.
+                Can span multiple lines.
+            fragile: Whether the contents break easily.
+        """
+        return address
+
+    props = _schema(deliver)["properties"]
+    assert props["address"]["description"] == (
+        "Street address to ship to. Can span multiple lines."
+    )
+    assert (
+        props["fragile"]["description"] == "Whether the contents break easily."
+    )
+    # `note` has no docstring entry and no Field: no description is invented.
+    assert "description" not in props["note"]
+
+
+def test_annotated_description_wins_over_docstring() -> None:
+    @ai.tool
+    async def park(
+        plate: Annotated[
+            str, pydantic.Field(description="License plate number")
+        ],
+    ) -> str:
+        """Park a car.
+
+        Args:
+            plate: The plate, apparently.
+        """
+        return plate
+
+    assert (
+        _schema(park)["properties"]["plate"]["description"]
+        == "License plate number"
+    )
+
+
+def test_docstring_without_args_leaves_schema_untouched() -> None:
+    @ai.tool
+    async def ping(host: str) -> str:
+        """Ping a host. Returns latency in ms.
+
+        Returns:
+            Latency string.
+        """
+        return host
+
+    schema_before = {
+        "properties": {"host": {"title": "Host", "type": "string"}},
+        "required": ["host"],
+        "title": "ping_Args",
+        "type": "object",
+    }
+    assert _schema(ping) == schema_before
+
+
+def test_docstring_param_names_not_in_signature_are_ignored() -> None:
+    @ai.tool
+    async def bake(kind: str) -> str:
+        """Bake something.
+
+        Args:
+            kind: What to bake.
+            oven_secret: Not a real parameter.
+        """
+        return kind
+
+    props = _schema(bake)["properties"]
+    assert "oven_secret" not in props
+    assert props["kind"]["description"] == "What to bake."
+
+
+def test_plain_hints_schema_is_byte_identical_to_pre_change_behavior() -> None:
+    @ai.tool
+    async def greet(name: str, count: int = 1) -> str:
+        """Say hello."""
+        return "hi" * count
+
+    assert _schema(greet) == {
+        "properties": {
+            "count": {"default": 1, "title": "Count", "type": "integer"},
+            "name": {"title": "Name", "type": "string"},
+        },
+        "required": ["name"],
+        "title": "greet_Args",
+        "type": "object",
+    }


### PR DESCRIPTION
Closes #270

## What

Two mechanisms for parameter descriptions on `@ai.tool` functions:

1. `Annotated[str, Field(description=...)]` now survives into the schema — the fix is `get_type_hints(fn, include_extras=True)`; pydantic carries the metadata through `create_model().model_json_schema()` unchanged.
2. A Google-style `Args:` docstring section fills descriptions for parameters without a `Field` description. `Field` wins when both exist.

## Why

Descriptions are how the model judges which tool to call and what each argument means. Both idiomatic typed-Python patterns were silently dropped, so every tool built this way shipped undocumented arguments.

## Notes

- No new dependencies (the parser is ~40 lines in `agent.py`, Google-style only).
- Tools using neither mechanism get byte-identical schemas; there is a regression test pinning that.
- The tool description itself stays the full docstring — trimming the `Args:` block from it felt like a separate behavior decision, happy to follow up if wanted.
- Every provider protocol embeds `spec.params` verbatim (`openai/protocol.py`, `anthropic/protocol.py`, `ai_gateway/protocol.py`), so descriptions reach all models with no per-provider changes.

## Validation

- `uv run pytest`: 768 passed (8 new tests covering annotated fields, nested `Annotated[...] | None` unions keeping constraints + description, multiline Args entries, Field-over-docstring precedence, unknown-name tolerance, and the byte-identical regression)
- `uv run ruff format --check` / `ruff check`: clean
- `uv run mypy`: 35 errors, identical to baseline on `main` (all pre-existing, none in touched code)
- `uv run ty check`: clean