### PR TITLE
Add a to_model_input argument to the tool decorator

### DIFF
--- a/docs/ai-python/content/docs/reference/ai/tool-decorator.mdx
+++ b/docs/ai-python/content/docs/reference/ai/tool-decorator.mdx
@@ -25,6 +25,9 @@ async def name(...) -> Result: ...
 
 @ai.tool(aggregator=...)
 async def name(...) -> AsyncIterable[Item]: ...
+
+@ai.tool(to_model_input=...)
+async def name(...) -> Result: ...
 ```
 
 The function name becomes the tool name. The docstring becomes the tool
@@ -34,6 +37,35 @@ schema.
 The decorated callable must return an awaitable or an async iterable. Every
 async iterable tool needs an aggregator. Pass `aggregator=` or annotate the
 return type with an `ai.agents.Aggregate` marker, but do not use both.
+
+## Sending the model something else
+
+`to_model_input=` takes a callable that converts the tool's result into the
+value the model sees. The full result stays on the `ToolResultPart` for the UI
+and for session persistence:
+
+```python
+class EditResult(pydantic.BaseModel):
+    message: str
+    old_content: str
+    new_content: str
+
+
+@ai.tool(to_model_input=lambda r: r.message)
+async def edit(path: str, ...) -> EditResult:
+    """Edit a file."""
+    ...
+```
+
+The model sees `"Successfully replaced 2 block(s) in f.py."`; the UI still has
+both file versions to render a diff from.
+
+The callable receives the tool's return value, and is not called for a tool
+that raised.
+
+`to_model_input=` and an aggregator are mutually exclusive -- a streaming tool
+derives the model-facing value from its aggregator's own `to_model_input`, so
+declaring both raises `TypeError`.
 
 For model-facing tool declarations and provider-executed tools, use
 [`ai.tools`](/docs/reference/tools).

--- a/src/ai/agents/agent.py
+++ b/src/ai/agents/agent.py
@@ -174,10 +174,9 @@ def _populate_model_inputs(
 ) -> None:
     """Set ``model_input`` on tool results that arrived without one.
 
-    Aggregator tool execution sets ``model_input`` directly; this fills
-    in the value for aggregator results that were reconstructed from a
-    wire round-trip (e.g. the AI SDK UI inbound path) and never had it
-    computed.
+    Tool execution sets ``model_input`` directly; this fills in the
+    value for results that were reconstructed from a wire round-trip
+    (e.g. the AI SDK UI inbound path) and never had it computed.
     """
     for msg in messages:
         if msg.role != "tool":
@@ -188,10 +187,13 @@ def _populate_model_inputs(
             tool = tools_by_name.get(part.tool_name)
             if tool is None:
                 continue
-            agg_cls = _aggregator_cls(tool.aggregator)
-            if agg_cls is None:
-                continue
-            part.set_model_input(agg_cls.to_model_input(part.result))
+            convert = tool.to_model_input
+            if convert is None:
+                agg_cls = _aggregator_cls(tool.aggregator)
+                if agg_cls is None:
+                    continue
+                convert = agg_cls.to_model_input
+            part.set_model_input(convert(part.result))
 
 
 class SimpleAggregator[Item, Result](events_.Aggregator[Item, Result, Result]):
@@ -461,6 +463,7 @@ class AgentTool:
     fn: Callable[..., Any]
     validator: type[pydantic.BaseModel] | None = None
     aggregator: Callable[[], events_.Aggregator[Any, Any, Any]] | None = None
+    to_model_input: Callable[[Any], Any] | None = None
     return_type: Any = None
 
     @property
@@ -501,6 +504,7 @@ def tool[**P, T](fn: Callable[P, AsyncIterable[T]], /) -> AgentTool: ...
 def tool[**P](
     *,
     require_approval: bool,
+    to_model_input: Callable[[Any], Any] | None = None,
     return_type: Any = None,
 ) -> Callable[
     [Callable[P, Awaitable[Any] | AsyncIterable[Any]]], AgentTool
@@ -512,6 +516,7 @@ def tool[**P](
     *,
     return_type: Any,
     require_approval: bool = False,
+    to_model_input: Callable[[Any], Any] | None = None,
 ) -> Callable[
     [Callable[P, Awaitable[Any] | AsyncIterable[Any]]], AgentTool
 ]: ...
@@ -526,12 +531,24 @@ def tool[**P](
 ) -> Callable[[Callable[P, AsyncIterable[Any]]], AgentTool]: ...
 
 
+@overload
+def tool[**P](
+    *,
+    to_model_input: Callable[[Any], Any],
+    require_approval: bool = False,
+    return_type: Any = None,
+) -> Callable[
+    [Callable[P, Awaitable[Any] | AsyncIterable[Any]]], AgentTool
+]: ...
+
+
 def tool[**P, T, R](
     fn: Callable[P, Awaitable[R]] | Callable[P, AsyncIterable[T]] | None = None,
     /,
     *,
     aggregator: Callable[[], events_.Aggregator[Any, Any, Any]] | None = None,
     require_approval: bool = False,
+    to_model_input: Callable[[Any], Any] | None = None,
     return_type: Any = None,
 ) -> (
     Callable[[Callable[P, AsyncIterable[Any]]], AgentTool]
@@ -546,6 +563,18 @@ def tool[**P, T, R](
     or :data:`StreamingStatusTool` aliases).  Specifying both raises
     ``TypeError``. Pass ``return_type=`` to override the type used when
     validating round-tripped tool results.
+
+    Pass ``to_model_input=`` to send the model something other than the
+    result the tool produced -- useful when the result carries detail
+    the UI needs but the model shouldn't pay tokens for::
+
+        @ai.tool(to_model_input=lambda r: r.message)
+        async def edit(path: str) -> EditResult:
+            ...
+
+    It receives the tool's return value, and is mutually exclusive with
+    an aggregator -- a streaming tool derives the model-facing value
+    from the aggregator instead.
     """
 
     def wrap(fn: Any) -> AgentTool:
@@ -571,6 +600,12 @@ def tool[**P, T, R](
                 "in the return-type annotation; specify only one"
             )
         effective_aggregator = aggregator or annotated_aggregate
+        if effective_aggregator is not None and to_model_input is not None:
+            raise TypeError(
+                f"Tool {fn.__name__!r}: `to_model_input=` cannot be combined "
+                "with an aggregator; the aggregator's own `to_model_input` "
+                "already derives the model-facing value"
+            )
 
         tool_decl = Tool(
             kind="function",
@@ -587,6 +622,7 @@ def tool[**P, T, R](
             fn=fn,
             validator=validator,
             aggregator=effective_aggregator,
+            to_model_input=to_model_input,
             return_type=return_type
             or _tool_result_type_from_return_annotation(
                 annotated_return_type, effective_aggregator
@@ -719,6 +755,8 @@ class BoundToolCall:
                         f"async iterable, not {type(returned).__name__}; "
                         f"declare it with `async def`"
                     )
+                if tool.to_model_input is not None:
+                    model_input = tool.to_model_input(result)
             except (Exception, asyncio.CancelledError) as exc:
                 return _error_tool_result(
                     exc,

--- a/tests/agents/test_tools.py
+++ b/tests/agents/test_tools.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Callable
+from collections.abc import AsyncGenerator, Callable
 from typing import Any, cast
 
 import pydantic
@@ -16,6 +16,13 @@ from ai.types import events as events_
 # through an untyped view of the decorator to reach the runtime check.
 _untyped_tool = cast(
     "Callable[[Callable[..., Any]], ai.AgentTool]",
+    ai.tool,
+)
+
+# Combining an aggregator with to_model_input is a type error by
+# design; reach the runtime check the same way.
+_untyped_tool_kw = cast(
+    "Callable[..., Callable[[Callable[..., Any]], ai.AgentTool]]",
     ai.tool,
 )
 
@@ -393,3 +400,104 @@ async def test_tool_call_with_nested_pydantic_model() -> None:
     ), f"expected _NestedItem instances, got {[type(i) for i in received]}"
     assert received[0].key == "a"
     assert received[1].value == "2"
+
+
+# -- to_model_input -------------------------------------------------------
+
+
+async def _run_tool(tool: ai.AgentTool, args: str = "{}") -> Any:
+    part = ai.messages.ToolCallPart(
+        tool_call_id=f"tc-{tool.name}",
+        tool_name=tool.name,
+        tool_args=args,
+    )
+    result = await ai.agents.BoundToolCall(part=part, tool=tool)()
+    return result.results[0]
+
+
+class _EditResult(pydantic.BaseModel):
+    message: str
+    old_content: str
+    new_content: str
+
+
+async def test_to_model_input_transforms_what_the_model_sees() -> None:
+    """The result keeps the full value; the model sees the conversion."""
+
+    @ai.tool(to_model_input=lambda r: r.message)
+    async def edit(path: str) -> _EditResult:
+        """Edit a file."""
+        return _EditResult(
+            message=f"edited {path}", old_content="a", new_content="b"
+        )
+
+    part = await _run_tool(edit, '{"path": "f.py"}')
+
+    assert isinstance(part.result, _EditResult)
+    assert part.result.old_content == "a"
+    assert part.has_model_input
+    assert part.get_model_input() == "edited f.py"
+
+
+async def test_to_model_input_not_called_without_it() -> None:
+    @ai.tool
+    async def plain() -> str:
+        """Plain tool."""
+        return "hello"
+
+    part = await _run_tool(plain)
+
+    assert not part.has_model_input
+    assert part.get_model_input() == "hello"
+
+
+async def test_to_model_input_not_called_on_error() -> None:
+    calls: list[Any] = []
+
+    @ai.tool(to_model_input=calls.append)
+    async def boom() -> str:
+        """Always fails."""
+        raise RuntimeError("nope")
+
+    part = await _run_tool(boom)
+
+    assert part.is_error
+    assert not part.has_model_input
+    assert calls == []
+
+
+async def test_to_model_input_failure_becomes_a_tool_error() -> None:
+    def convert(result: str) -> str:
+        raise ValueError("bad conversion")
+
+    @ai.tool(to_model_input=convert)
+    async def t() -> str:
+        """Tool."""
+        return "ok"
+
+    part = await _run_tool(t)
+
+    assert part.is_error
+    assert "bad conversion" in str(part.result)
+
+
+def test_to_model_input_with_aggregator_is_rejected() -> None:
+    with pytest.raises(TypeError, match="cannot be combined"):
+
+        @_untyped_tool_kw(
+            aggregator=ai.agents.LastAggregator,
+            to_model_input=str,
+        )
+        async def t() -> AsyncGenerator[str]:
+            """Stream."""
+            yield "x"
+
+
+def test_to_model_input_with_aggregate_marker_is_rejected() -> None:
+    """The marker form of the aggregator conflicts too."""
+    with pytest.raises(TypeError, match="cannot be combined"):
+
+        @ai.tool(to_model_input=str)
+        async def t() -> ai.StreamingTextTool:
+            """Stream."""
+            yield "x"


### PR DESCRIPTION
We need a way to allow non-streaming tools to customize their output
for the model.
