### PR TITLE
Add a priority flag to merge

### DIFF
--- a/src/ai/util.py
+++ b/src/ai/util.py
@@ -260,12 +260,19 @@ async def decouple[T](
 
 
 async def merge[T](
-    *aiterables: AsyncIterable[T], restart: bool = True
+    *aiterables: AsyncIterable[T],
+    restart: bool = True,
+    priority: bool = False,
 ) -> AsyncGenerator[T]:
     """Yield elements from async iterables as they arrive.
 
     The first anext() call on each iterable is done eagerly, but
     after that they run in lockstep with the consumer of merge.
+
+    If `priority` is True (default is False), then earlier async
+    iterables take priority over later ones. We will always yield
+    a value if available from an earlier one before yielding from
+    a later.
 
     Additionally, if `restart` is True (the default), attempt to *restart*
     finished iterables when other iterables produce elements.
@@ -277,11 +284,13 @@ async def merge[T](
     Restarts are only attempted for iterables that are not their own
     iterators (importantly, this means that async generators are not
     restarted).
+
+    Restart and priority are incompatible.
     """
-    async with (
-        TaskGroup() as tg,
-        MultiWaiter[T]() as mw,
-    ):
+    if priority and restart:
+        raise ValueError("cannot specify priority=True and restart=True")
+
+    async with TaskGroup() as tg:
         raw_aiters = [aiter(iter) for iter in aiterables]
         aiters = [decouple(iter, task_group=tg) for iter in raw_aiters]
         # We consider anything that doesn't __aiter__ to itself to be
@@ -295,40 +304,52 @@ async def merge[T](
         tasks: list[asyncio.Future[T] | None] = [
             tg.create_task(anext(iter, _EMPTY)) for iter in aiters
         ]
-        mw.add(*[t for t in tasks if t])
 
-        top_fired = False
-        while t := await mw:
-            idx = tasks.index(t)
-            val = t.result()
-            if val is _EMPTY:
-                tasks[idx] = None
-            else:
-                yield val
-                # Fire off a new task for the relevant iterator.
-                # Done after the yield to stay in lock-step with demand.
-                tasks[idx] = nt = tg.create_task(anext(aiters[idx], _EMPTY))
-                mw.add(nt)
-                top_fired = True
+        while any(tasks):
+            pending = [t for t in tasks if t]
+            done_set, _ = await asyncio.wait(
+                pending,
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            # We might see an exception before the callback that
+            # cancels the main task makes it in, so check.
+            if any(t.exception() for t in done_set):
+                return
 
-            if restart and (
-                val is not _EMPTY or (not mw.tasks() and top_fired)
-            ):
-                if not mw.tasks():
-                    top_fired = False
+            done = sorted(done_set, key=pending.index)
+
+            fired = []
+            for t in done:
+                idx = tasks.index(t)
+                val = t.result()
+                if val is _EMPTY:
+                    tasks[idx] = None
+                else:
+                    yield val
+                    # Fire off a new task for the relevant iterator
+                    fired.append(idx)
+                    iter = aiters[idx]
+                    tasks[idx] = tg.create_task(anext(iter, _EMPTY))
+                    # sleep(0) to approximate 3.14's eager_start. Make
+                    # sure that a trivially read task (like a get() on
+                    # a queue with elements) can run to completion.
+                    await asyncio.sleep(0)
+
+                if priority:
+                    break
+
+            if restart and fired:
                 # Also, we try *restarting* other stopped streams
                 # that may have more to do now.
-                #
                 # N.B: We do this *after* the values are yielded, so
-                # they've had a chance to trigger things, and we also
-                # do it if we would otherwise terminate and we have
-                # seen any elements since the start or the last time
-                # we may have been exhausted.
+                # they've had a chance to trigger things, and we do it
+                # after *all* tasks have been handled, so that if a
+                # task *just* finished, we still restart it.
                 for idx, (ok, otask) in enumerate(
                     zip(restartable, tasks, strict=True)
                 ):
-                    if ok and otask is None:
-                        niter = decouple(aiterables[idx], task_group=tg)
-                        aiters[idx] = niter
-                        tasks[idx] = nt = tg.create_task(anext(niter, _EMPTY))
-                        mw.add(nt)
+                    if ok and otask is None and idx not in fired:
+                        niter = aiters[idx] = decouple(
+                            aiterables[idx], task_group=tg
+                        )
+                        tasks[idx] = tg.create_task(anext(niter, _EMPTY))

--- a/tests/agents/test_generator_tools.py
+++ b/tests/agents/test_generator_tools.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import AsyncGenerator, AsyncIterator, Sequence
 from typing import Any
 
@@ -76,6 +77,37 @@ async def test_generator_tool_streams_and_returns_result() -> None:
     assert part.result == "Answer for test"
     assert part.has_model_input
     assert part.get_model_input() == "Answer for test"
+
+
+@ai.tool(aggregator=ai.agents.LastAggregator)
+async def chatty_tool(query: str) -> AsyncGenerator[str]:
+    """Tool that streams several values back to back."""
+    for i in range(5):
+        yield f"progress-{i}"
+
+
+async def test_partials_precede_tool_result_with_slow_consumer() -> None:
+    """PartialToolCallResults are never overtaken by the tool's final
+    ToolCallResult, even when the consumer stalls between events and
+    the partials back up on the runtime queue."""
+    my_agent = ai.Agent(tools=[chatty_tool])
+    call = [
+        tool_call_msg(tc_id="tc-1", name="chatty_tool", args='{"query": "x"}')
+    ]
+    reply = [text_msg("Done!", id="msg-2")]
+    mock_llm([call, reply])
+
+    order: list[str] = []
+    async with my_agent.run(MOCK_MODEL, [ai.user_message("Go")]) as stream:
+        async for event in stream:
+            if isinstance(event, agent_events_.PartialToolCallResult):
+                order.append(f"partial:{event.value}")
+            elif isinstance(event, agent_events_.ToolCallResult):
+                order.append("result")
+            for _ in range(10):
+                await asyncio.sleep(0)
+
+    assert order == [f"partial:progress-{i}" for i in range(5)] + ["result"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -471,6 +471,89 @@ async def test_merge_lockstep() -> None:
             assert advanced == list(range(n + 1))
 
 
+# -- merge: priority=True ---------------------------------------------------
+
+
+async def test_merge_priority_rejects_restart() -> None:
+    """priority=True with restart=True (the default) is an error."""
+    with pytest.raises(ValueError, match="priority"):
+        await _collect(util.merge(_from_list([1]), priority=True))
+
+
+async def test_merge_priority_buffered_elements_first() -> None:
+    """Elements queued on the high-priority iterable before a
+    low-priority element was produced always come out first, even
+    with a prompt consumer -- no stalls anywhere."""
+    for n_queued in (1, 2, 3, 5, 8):
+        queue: util.AsyncIterableQueue[str] = util.AsyncIterableQueue()
+
+        async def src(
+            n: int = n_queued,
+            q: util.AsyncIterableQueue[str] = queue,
+        ) -> AsyncIterator[str]:
+            for i in range(n):
+                await q.put(f"q{i}")
+            yield "src"
+            await q.astop()
+
+        got = await _collect(
+            util.merge(queue, src(), restart=False, priority=True)
+        )
+        assert got == [f"q{i}" for i in range(n_queued)] + ["src"], n_queued
+
+
+async def test_merge_priority_interleaved_puts() -> None:
+    """Puts interleaved with source yields precede the *next* source
+    element, round after round."""
+    queue: util.AsyncIterableQueue[str] = util.AsyncIterableQueue()
+
+    async def src() -> AsyncIterator[str]:
+        for i in range(20):
+            await queue.put(f"q{i}a")
+            await queue.put(f"q{i}b")
+            yield f"s{i}"
+        await queue.astop()
+
+    got = await _collect(util.merge(queue, src(), restart=False, priority=True))
+    for i in range(20):
+        a, b, s = got.index(f"q{i}a"), got.index(f"q{i}b"), got.index(f"s{i}")
+        assert a < b < s, (i, got)
+
+
+async def test_merge_priority_position_breaks_ties() -> None:
+    """When several iterables have elements ready, the earliest one
+    wins, repeatedly, until it runs dry."""
+    q1: util.AsyncIterableQueue[str] = util.AsyncIterableQueue()
+    q2: util.AsyncIterableQueue[str] = util.AsyncIterableQueue()
+    for q, tag in ((q1, "a"), (q2, "b")):
+        q.put_nowait(f"{tag}1")
+        q.put_nowait(f"{tag}2")
+        await q.astop()
+
+    got = await _collect(util.merge(q1, q2, restart=False, priority=True))
+    assert got == ["a1", "a2", "b1", "b2"]
+
+
+async def test_merge_priority_source_lockstep() -> None:
+    """A low-priority source still follows the demand contract while a
+    high-priority iterable sits idle."""
+    advanced: list[int] = []
+    queue: util.AsyncIterableQueue[int] = util.AsyncIterableQueue()
+
+    async def src() -> AsyncIterator[int]:
+        for i in range(10):
+            advanced.append(i)
+            yield i
+
+    it = util.merge(queue, src(), restart=False, priority=True)
+    async with util.maybe_aclosing(it):
+        for n in range(5):
+            assert await anext(it) == n
+            for _ in range(50):
+                await asyncio.sleep(0)
+            assert advanced == list(range(n + 1))
+
+
 async def test_decouple_contextvar_stable_across_yields() -> None:
     """ContextVars set in the source persist across decouple yields."""
     var: contextvars.ContextVar[str] = contextvars.ContextVar("test")
@@ -612,7 +695,7 @@ async def test_merge_restarts_restartable_iterable() -> None:
     result = await _collect(util.merge(driver(), src))
     assert sorted(result) == ["d1", "d2", "d3", "r1", "r2", "r3", "r4"]
     # __aiter__ called once initially, and once more at the end.
-    assert src.iter_count == 5
+    assert src.iter_count == 4
 
 
 async def test_merge_does_not_restart_async_generator() -> None:
@@ -667,7 +750,7 @@ async def test_merge_restart_with_no_new_items_terminates() -> None:
     result = await _collect(util.merge(driver(), src))
     assert sorted(result) == ["d1", "d2", "only"]
     # Still re-iterated once per driver yield, and once more at the end.
-    assert src.iter_count == 4
+    assert src.iter_count == 3
 
 
 async def test_merge_restart_with_multiple_restartables() -> None:
@@ -685,8 +768,8 @@ async def test_merge_restart_with_multiple_restartables() -> None:
 
     result = await _collect(util.merge(driver(), a, b))
     assert sorted(result) == ["a1", "a2", "b1", "b2", "d1"]
-    assert a.iter_count == 3
-    assert b.iter_count == 3
+    assert a.iter_count == 2
+    assert b.iter_count == 2
 
 
 async def test_merge_restart_only_after_other_iterable_yields() -> None:
@@ -698,7 +781,7 @@ async def test_merge_restart_only_after_other_iterable_yields() -> None:
     # __aiter__ being called again, and once more at the end.
     result = await _collect(util.merge(src))
     assert result == ["r1"]
-    assert src.iter_count == 2
+    assert src.iter_count == 1
 
 
 async def test_merge_restart_when_yield_and_stop_collide() -> None:


### PR DESCRIPTION
We are going to want to be able to do a merge where one of the
arguments (the _event_queue) is prioritized, and will always yield if
available instead of other iterators.

The old asyncio.wait() based implementation of merge() made that much
easier to add, so revert back to that and add it.
