### PR TITLE
Support running Agent.loop in lockstep with consumer of Agent.run

### DIFF
--- a/docs/ai-python/content/docs/basics/custom-loops.mdx
+++ b/docs/ai-python/content/docs/basics/custom-loops.mdx
@@ -10,12 +10,15 @@ branching. While the SDK defines the loop as a Python async generator, it still
 uses a few framework components. Reuse those to retain framework-controlled
 behavior.
 
-Note that `loop` does not run in lock-step with the code that iterates the
-stream. The framework runs it as a separate asyncio task that puts events on a
-queue, and the `agent.run` stream reads from that queue. This means the loop
-can keep making progress (for example, launching tools) while the consumer is
-between reads, and events you `yield` may be consumed later than they are
-produced.
+Note that, by default, `loop` does not run in lock-step with the code
+that iterates the stream. The framework runs it as a separate asyncio
+task that puts events on a queue, and the `agent.run` stream reads
+from that queue. This means the loop can keep making progress (for
+example, launching tools) while the consumer is between reads, and
+events you `yield` may be consumed later than they are produced.
+This is controlled by the `buffer` parameter to `Agent.run`: with `None`,
+the default, an unbounded number of events will be buffer. With `0`,
+the `loop` will run in lockstep.
 
 ## Explore the standard loop shape
 
@@ -58,5 +61,5 @@ class CustomAgent(ai.Agent):
                 context.add(tool_runner.get_tool_message())
 ```
 
-You can modify most of the loop and extend `CustomAgent` to fit your application's needs, 
+You can modify most of the loop and extend `CustomAgent` to fit your application's needs,
 and the SDK will keep working as long as the loop is still an async generator of events.

--- a/docs/ai-python/content/docs/basics/custom-loops.mdx
+++ b/docs/ai-python/content/docs/basics/custom-loops.mdx
@@ -15,10 +15,10 @@ that iterates the stream. The framework runs it as a separate asyncio
 task that puts events on a queue, and the `agent.run` stream reads
 from that queue. This means the loop can keep making progress (for
 example, launching tools) while the consumer is between reads, and
-events you `yield` may be consumed later than they are produced.
-This is controlled by the `buffer` parameter to `Agent.run`: with `None`,
-the default, an unbounded number of events will be buffer. With `0`,
-the `loop` will run in lockstep.
+events you `yield` may be consumed later than they are produced.  This
+can be changed by overriding by the `LOOP_BUFFER` class variable in an
+`Agent` subclass: with `None`, the default, an unbounded number of
+events will be buffered. With `0`, the `loop` will run in lockstep.
 
 ## Explore the standard loop shape
 

--- a/docs/ai-python/content/docs/reference/ai/agent.mdx
+++ b/docs/ai-python/content/docs/reference/ai/agent.mdx
@@ -23,6 +23,7 @@ async with agent.run(
     messages,
     output_type=None,
     params=None,
+    buffer=None,
 ) as stream:
     async for event in stream:
         ...
@@ -34,6 +35,9 @@ Arguments:
 - `messages`: initial list of `ai.messages.Message`.
 - `output_type`: optional Pydantic model for final JSON output.
 - `params`: optional `ai.InferenceRequestParams`.
+- `buffer`: how many events the loop may run ahead of the consumer. `None`
+  (the default) is unbounded, so the loop keeps going while the consumer is
+  between reads. `0` runs the loop in lockstep with the consumer.
 
 ## AgentStream
 

--- a/docs/ai-python/content/docs/reference/ai/agent.mdx
+++ b/docs/ai-python/content/docs/reference/ai/agent.mdx
@@ -23,7 +23,6 @@ async with agent.run(
     messages,
     output_type=None,
     params=None,
-    buffer=None,
 ) as stream:
     async for event in stream:
         ...
@@ -35,9 +34,6 @@ Arguments:
 - `messages`: initial list of `ai.messages.Message`.
 - `output_type`: optional Pydantic model for final JSON output.
 - `params`: optional `ai.InferenceRequestParams`.
-- `buffer`: how many events the loop may run ahead of the consumer. `None`
-  (the default) is unbounded, so the loop keeps going while the consumer is
-  between reads. `0` runs the loop in lockstep with the consumer.
 
 ## AgentStream
 
@@ -67,6 +63,17 @@ class CustomAgent(ai.Agent):
     async def loop(self, context: ai.Context):
         while context.keep_running():
             ...
+```
+
+`LOOP_BUFFER` is a class variable that sets how many events `loop` may run
+ahead of the consumer of `run`. `None` (the default) is unbounded, so the loop
+keeps going while the consumer is between reads. `0` runs the loop in lockstep
+with the consumer, which loops that sequence side effects against consumer
+code depend on.
+
+```python
+class DurableAgent(ai.Agent):
+    LOOP_BUFFER = 0
 ```
 
 When persisting a run (for durability or serverless execution), save and

--- a/docs/ai-python/content/docs/reference/util.mdx
+++ b/docs/ai-python/content/docs/reference/util.mdx
@@ -21,8 +21,7 @@ async for event in ai.util.merge(stream, tool_runner.events()):
 
 `decouple` runs an async iterable in its own task and hands its items to the
 consumer through a buffer. Use it to let a producer keep going while the
-consumer is slow. (`Agent.run` exposes this directly through its `buffer`
-argument.)
+consumer is slow. (`Agent.LOOP_BUFFER` exposes this for the agent loop.)
 
 ```python
 async for item in ai.util.decouple(source, buffer=None):

--- a/src/ai/agents/agent.py
+++ b/src/ai/agents/agent.py
@@ -1392,6 +1392,7 @@ class Agent:
         messages: list[types.messages.Message],
         *,
         params: models.InferenceRequestParams | None = None,
+        buffer: int | None = None,
         hook_registry: hooks_.HookRegistry | None = None,
         _middleware: list[middleware_._Middleware] | None = None,
     ) -> AbstractAsyncContextManager[AgentStream[str]]: ...
@@ -1403,6 +1404,7 @@ class Agent:
         *,
         output_type: type[T],
         params: models.InferenceRequestParams | None = None,
+        buffer: int | None = None,
         hook_registry: hooks_.HookRegistry | None = None,
         _middleware: list[middleware_._Middleware] | None = None,
     ) -> AbstractAsyncContextManager[AgentStream[T]]: ...
@@ -1413,6 +1415,7 @@ class Agent:
         *,
         output_type: type[pydantic.BaseModel] | None = None,
         params: models.InferenceRequestParams | None = None,
+        buffer: int | None = None,
         hook_registry: hooks_.HookRegistry | None = None,
         _middleware: list[middleware_._Middleware] | None = None,
     ) -> AbstractAsyncContextManager[AgentStream[Any]]:
@@ -1432,6 +1435,11 @@ class Agent:
             output_type: Optional Pydantic model the model's output must
                 conform to.  When set, ``stream.output`` validates the
                 final assistant message's text against it.
+            buffer: How many events the loop may run ahead of the
+                consumer.  ``None`` (the default) is unbounded: the loop
+                keeps going while the consumer is between reads.  ``0``
+                runs the loop in lockstep, so it is only advanced when
+                the consumer asks for an event.
             hook_registry: The :class:`~ai.agents.hooks.HookRegistry`
                 for this run's hooks.  Defaults to the current registry
                 (so a nested run joins the enclosing run's hooks), or a
@@ -1448,6 +1456,7 @@ class Agent:
             messages,
             output_type=output_type,
             params=params,
+            buffer=buffer,
             hook_registry=hook_registry,
             _middleware=_middleware,
         )
@@ -1460,6 +1469,7 @@ class Agent:
         *,
         output_type: type[pydantic.BaseModel] | None,
         params: models.InferenceRequestParams | None,
+        buffer: int | None,
         hook_registry: hooks_.HookRegistry | None,
         _middleware: list[middleware_._Middleware] | None,
     ) -> AsyncIterator[AgentStream[Any]]:
@@ -1531,7 +1541,9 @@ class Agent:
                     mw_token = middleware_.activate(parent + _middleware)
                 try:
                     chain = middleware_._build_agent_run_chain(_real)
-                    async with contextlib.aclosing(chain(context)) as events:
+                    async with contextlib.aclosing(
+                        util.decouple(chain(context), buffer=buffer)
+                    ) as events:
                         async for event in events:
                             # a blocked run can only resume via a hook
                             # resolution or cancellation, so a non-pending

--- a/src/ai/agents/agent.py
+++ b/src/ai/agents/agent.py
@@ -1338,6 +1338,15 @@ class Agent:
     extend the class-level set per instance.
     """
 
+    LOOP_BUFFER: ClassVar[int | None] = None
+    """How many events ``loop`` may run ahead of the consumer of ``run``.
+
+    ``None`` (the default) is unbounded: the loop keeps going while the
+    consumer is between reads. ``0`` runs the loop in lockstep, so it is
+    only advanced when the consumer asks for an event; loops that
+    sequence side effects against consumer code depend on this.
+    """
+
     def __init__(
         self,
         *,
@@ -1392,7 +1401,6 @@ class Agent:
         messages: list[types.messages.Message],
         *,
         params: models.InferenceRequestParams | None = None,
-        buffer: int | None = None,
         hook_registry: hooks_.HookRegistry | None = None,
         _middleware: list[middleware_._Middleware] | None = None,
     ) -> AbstractAsyncContextManager[AgentStream[str]]: ...
@@ -1404,7 +1412,6 @@ class Agent:
         *,
         output_type: type[T],
         params: models.InferenceRequestParams | None = None,
-        buffer: int | None = None,
         hook_registry: hooks_.HookRegistry | None = None,
         _middleware: list[middleware_._Middleware] | None = None,
     ) -> AbstractAsyncContextManager[AgentStream[T]]: ...
@@ -1415,7 +1422,6 @@ class Agent:
         *,
         output_type: type[pydantic.BaseModel] | None = None,
         params: models.InferenceRequestParams | None = None,
-        buffer: int | None = None,
         hook_registry: hooks_.HookRegistry | None = None,
         _middleware: list[middleware_._Middleware] | None = None,
     ) -> AbstractAsyncContextManager[AgentStream[Any]]:
@@ -1435,11 +1441,6 @@ class Agent:
             output_type: Optional Pydantic model the model's output must
                 conform to.  When set, ``stream.output`` validates the
                 final assistant message's text against it.
-            buffer: How many events the loop may run ahead of the
-                consumer.  ``None`` (the default) is unbounded: the loop
-                keeps going while the consumer is between reads.  ``0``
-                runs the loop in lockstep, so it is only advanced when
-                the consumer asks for an event.
             hook_registry: The :class:`~ai.agents.hooks.HookRegistry`
                 for this run's hooks.  Defaults to the current registry
                 (so a nested run joins the enclosing run's hooks), or a
@@ -1456,7 +1457,6 @@ class Agent:
             messages,
             output_type=output_type,
             params=params,
-            buffer=buffer,
             hook_registry=hook_registry,
             _middleware=_middleware,
         )
@@ -1469,7 +1469,6 @@ class Agent:
         *,
         output_type: type[pydantic.BaseModel] | None,
         params: models.InferenceRequestParams | None,
-        buffer: int | None,
         hook_registry: hooks_.HookRegistry | None,
         _middleware: list[middleware_._Middleware] | None,
     ) -> AsyncIterator[AgentStream[Any]]:
@@ -1542,7 +1541,7 @@ class Agent:
                 try:
                     chain = middleware_._build_agent_run_chain(_real)
                     async with contextlib.aclosing(
-                        util.decouple(chain(context), buffer=buffer)
+                        util.decouple(chain(context), buffer=self.LOOP_BUFFER)
                     ) as events:
                         async for event in events:
                             # a blocked run can only resume via a hook

--- a/src/ai/agents/runtime.py
+++ b/src/ai/agents/runtime.py
@@ -12,7 +12,7 @@ from ..types import messages as messages_
 from .mcp import client as mcp_client
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncGenerator, Awaitable
+    from collections.abc import AsyncGenerator
 
 
 class Runtime:
@@ -47,20 +47,13 @@ def get_runtime() -> Runtime:
     return _runtime.get()
 
 
-async def _stop_when_done(runtime: Runtime, task: Awaitable[None]) -> None:
-    try:
-        await task
-    finally:
-        await runtime.signal_done()
-
-
-async def run(
+def run(
     source: AsyncGenerator[events_.AgentEvent],
 ) -> AsyncGenerator[events_.AgentEvent]:
     """Run *source* and yield events put into the Runtime queue."""
     rt = Runtime()
 
-    async def _drain() -> None:
+    async def _drain() -> AsyncGenerator[events_.AgentEvent]:
         # We do all of the contextvar stuff in _drain so that we don't
         # yield while we have outstanding contextvar manipulations.
         token = _runtime.set(rt)
@@ -70,11 +63,9 @@ async def run(
         mcp_token = mcp_client._pool.set(mcp_pool)
 
         try:
-            # aclosing: if this task is cancelled while *source* sits
-            # suspended at a yield, close it here
             async with contextlib.aclosing(source) as events:
                 async for event in events:
-                    await rt.put_event(event)
+                    yield event
 
         finally:
             await mcp_client.close_connections()
@@ -82,8 +73,8 @@ async def run(
 
             _runtime.reset(token)
 
-    async with util.TaskGroup() as tg:
-        tg.create_task(_stop_when_done(rt, _drain()))
+            await rt.signal_done()
 
-        async for item in rt._event_queue:
-            yield item
+    # Merge while prioritizing the _event_queue, so that partial tool
+    # results will always precede the real tool result.
+    return util.merge(rt._event_queue, _drain(), restart=False, priority=True)

--- a/src/ai/models/core/api.py
+++ b/src/ai/models/core/api.py
@@ -20,7 +20,7 @@ import pydantic
 # Use the typing_extensions backport so this works on 3.12 too.
 from typing_extensions import TypeVar
 
-from ... import errors, types
+from ... import errors, types, util
 from ... import experimental_telemetry as telemetry
 
 if TYPE_CHECKING:
@@ -605,7 +605,9 @@ async def _stream(
             params=params,
         )
         s = Stream(
-            executor._do_stream(request),
+            # buffer the results so that consuming the network stream
+            # isn't held up by a consumer not reading.
+            util.decouple(executor._do_stream(request), buffer=None),
             output_type=cast("type[Any] | None", output_type),
         )
         replay = False

--- a/tests/agents/test_runtime.py
+++ b/tests/agents/test_runtime.py
@@ -104,12 +104,15 @@ async def test_agent_run_buffers_by_default() -> None:
         ] == [str(i) for i in range(1, 10)]
 
 
-async def test_agent_run_buffer_zero_is_lockstep() -> None:
-    """With buffer=0 the loop is only advanced when the consumer asks."""
-    agent = _CountingAgent()
-    async with agent.run(
-        MOCK_MODEL, [ai.user_message("go")], buffer=0
-    ) as stream:
+class _LockstepAgent(_CountingAgent):
+    LOOP_BUFFER = 0
+
+
+async def test_agent_run_loop_buffer_zero_is_lockstep() -> None:
+    """With LOOP_BUFFER = 0 the loop is only advanced when the consumer
+    asks."""
+    agent = _LockstepAgent()
+    async with agent.run(MOCK_MODEL, [ai.user_message("go")]) as stream:
         it = aiter(stream)
         for n in range(5):
             ev = await anext(it)

--- a/tests/agents/test_runtime.py
+++ b/tests/agents/test_runtime.py
@@ -2,8 +2,13 @@
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
+from collections.abc import AsyncGenerator
+
 import ai
-from ai.types import messages
+from ai.agents import runtime
+from ai.types import events, messages
 
 from ..conftest import (
     MOCK_MODEL,
@@ -26,6 +31,93 @@ async def double(x: int) -> int:
 async def concat(a: str, b: str) -> str:
     """Concatenate strings."""
     return a + b
+
+
+# -- runtime.run ------------------------------------------------------------
+
+
+async def test_run_source_lockstep() -> None:
+    """run() only advances its source when the consumer asks for an event."""
+    advanced: list[int] = []
+
+    async def src() -> AsyncGenerator[events.AgentEvent]:
+        for i in range(10):
+            advanced.append(i)
+            yield events.TextDelta(chunk=str(i))
+
+    it = runtime.run(src())
+    async with contextlib.aclosing(it):
+        for n in range(5):
+            ev = await anext(it)
+            assert isinstance(ev, events.TextDelta)
+            assert ev.chunk == str(n)
+            # Give the pipeline every opportunity to run ahead.
+            for _ in range(50):
+                await asyncio.sleep(0)
+            assert advanced == list(range(n + 1))
+
+
+async def test_run_delivers_put_events() -> None:
+    """Events put on the Runtime queue by the source are yielded too."""
+
+    async def src() -> AsyncGenerator[events.AgentEvent]:
+        await runtime.get_runtime().put_event(events.TextDelta(chunk="side"))
+        yield events.TextDelta(chunk="main")
+
+    chunks: set[str] = set()
+    async with contextlib.aclosing(runtime.run(src())) as it:
+        async for ev in it:
+            assert isinstance(ev, events.TextDelta)
+            chunks.add(ev.chunk)
+    assert chunks == {"side", "main"}
+
+
+# -- Agent.run buffer -------------------------------------------------------
+
+
+class _CountingAgent(ai.Agent):
+    """Loop that records how far it has advanced."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.advanced: list[int] = []
+
+    async def loop(
+        self, context: ai.Context
+    ) -> AsyncGenerator[events.AgentEvent]:
+        for i in range(10):
+            self.advanced.append(i)
+            yield events.TextDelta(chunk=str(i))
+
+
+async def test_agent_run_buffers_by_default() -> None:
+    """With the default buffer, the loop keeps going while the consumer
+    is between reads."""
+    agent = _CountingAgent()
+    async with agent.run(MOCK_MODEL, [ai.user_message("go")]) as stream:
+        await anext(aiter(stream))
+        for _ in range(50):
+            await asyncio.sleep(0)
+        assert agent.advanced == list(range(10))
+        assert [
+            e.chunk async for e in stream if isinstance(e, events.TextDelta)
+        ] == [str(i) for i in range(1, 10)]
+
+
+async def test_agent_run_buffer_zero_is_lockstep() -> None:
+    """With buffer=0 the loop is only advanced when the consumer asks."""
+    agent = _CountingAgent()
+    async with agent.run(
+        MOCK_MODEL, [ai.user_message("go")], buffer=0
+    ) as stream:
+        it = aiter(stream)
+        for n in range(5):
+            ev = await anext(it)
+            assert isinstance(ev, events.TextDelta)
+            assert ev.chunk == str(n)
+            for _ in range(50):
+                await asyncio.sleep(0)
+            assert agent.advanced == list(range(n + 1))
 
 
 # -- Agent default loop: single turn (no tools) ----------------------------

--- a/tests/models/core/test_api.py
+++ b/tests/models/core/test_api.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from collections.abc import AsyncGenerator, Sequence
 from typing import Any, Literal, cast
 
@@ -83,6 +84,39 @@ async def test_stream_aggregates_registered_adapter_events() -> None:
         assert mock.call_count == 1
         assert stream.text == "Hello world"
         assert "".join(deltas) == "Hello world"
+
+
+async def test_stream_drains_provider_eagerly() -> None:
+    """The adapter is read to completion even if the consumer stalls,
+    so a slow consumer can't backpressure the provider connection."""
+    emitted: list[str] = []
+
+    async def _eager_stream(
+        model: models.Model,
+        messages: list[messages_.Message],
+        **kwargs: Any,
+    ) -> AsyncGenerator[events_.Event]:
+        yield events_.StreamStart()
+        yield events_.TextStart()
+        for i in range(5):
+            emitted.append(str(i))
+            yield events_.TextDelta(chunk=str(i))
+        yield events_.TextEnd()
+        emitted.append("end")
+        yield events_.StreamEnd()
+
+    MOCK_PROVIDER._stream_impl = _eager_stream
+
+    async with models.stream(MOCK_MODEL, [ai.user_message("Hi")]) as stream:
+        await anext(aiter(stream))
+        # Stall the consumer; the wire should still be drained.
+        for _ in range(50):
+            await asyncio.sleep(0)
+        assert emitted == ["0", "1", "2", "3", "4", "end"]
+        assert stream.text == ""  # nothing consumed beyond StreamStart
+        async for _event in stream:
+            pass
+        assert stream.text == "01234"
 
 
 async def test_stream_tool_end_includes_aggregated_tool_call() -> None:


### PR DESCRIPTION
Add a buffer argument to Agent.run that controls the buffer size.  The
default, `None`, maintains the current behavior of fully decoupling
them. At `buffer=0`, they will run in lockstep.

The reason I want this is so that a custom loop and client code that
do out-of-band messaging will interact in a predictable way.

(In particular, when doing a durable agent loop, I want to be able to
send all the streaming messages from the client code, but the messages
need to be queued *before* a new llm call is made.)
