### PR TITLE
Add an OmitEventMessages[...] wrapper that skips message bodies when dumping

### DIFF
--- a/src/ai/types/events.py
+++ b/src/ai/types/events.py
@@ -1,4 +1,5 @@
 import abc
+import contextvars
 from collections.abc import AsyncGenerator, Callable, Sequence
 from typing import Annotated, Any, Literal
 
@@ -17,6 +18,13 @@ from . import usage as usage_
 _DUMMY_MESSAGE = messages.Message(id="<unset>", role="assistant", parts=[])
 
 
+# Pydantic doesn't let an Annotated serializer add to the serialization
+# context, so OmitEventMessages uses a ContextVar instead.
+_omit_event_messages: contextvars.ContextVar[bool] = contextvars.ContextVar(
+    "ai_omit_event_messages", default=False
+)
+
+
 class BaseEvent(pydantic.BaseModel):
     """Anything ``ai.stream`` or ``Agent.run`` yields.
 
@@ -32,6 +40,44 @@ class BaseEvent(pydantic.BaseModel):
     model_config = pydantic.ConfigDict(frozen=True)
 
 
+def _serialize_omitting_event_messages(
+    value: Any,
+    handler: pydantic.SerializerFunctionWrapHandler,
+) -> Any:
+    token = _omit_event_messages.set(True)
+    try:
+        return handler(value)
+    finally:
+        _omit_event_messages.reset(token)
+
+
+type OmitEventMessages[T] = Annotated[
+    T, pydantic.WrapSerializer(_serialize_omitting_event_messages)
+]
+
+
+def _validate_event_message(value: Any) -> Any:
+    if isinstance(value, dict) and set(value) == {"id"}:
+        return {**value, "role": "assistant", "parts": []}
+    return value
+
+
+def _serialize_event_message(
+    value: messages.Message,
+    handler: pydantic.SerializerFunctionWrapHandler,
+) -> Any:
+    if _omit_event_messages.get():
+        return {"id": value.id}
+    return handler(value)
+
+
+type _EventMessage = Annotated[
+    messages.Message,
+    pydantic.BeforeValidator(_validate_event_message),
+    pydantic.WrapSerializer(_serialize_event_message),
+]
+
+
 class ModelEvent(BaseEvent):
     """Streamed out of a model request (``ai.stream``).
 
@@ -42,7 +88,7 @@ class ModelEvent(BaseEvent):
     across the stream).
     """
 
-    message: messages.Message = _DUMMY_MESSAGE
+    message: _EventMessage = _DUMMY_MESSAGE
     usage: usage_.Usage | None = None
     provider_metadata: dict[str, Any] | None = None
 

--- a/tests/types/test_events.py
+++ b/tests/types/test_events.py
@@ -2,8 +2,78 @@
 
 from __future__ import annotations
 
+import pydantic
+
 from ai import models
 from ai.types import events, messages
+
+
+def test_omitted_message_only_serializes_id() -> None:
+    adapter: pydantic.TypeAdapter[events.AgentEvent] = pydantic.TypeAdapter(
+        events.OmitEventMessages[events.AgentEvent]
+    )
+    message = messages.Message(
+        id="message-1",
+        role="assistant",
+        parts=[messages.TextPart(text="hello")],
+    )
+    event = events.TextDelta(message=message, chunk="hello")
+
+    result = adapter.dump_python(event)
+
+    assert result["message"] == {"id": "message-1"}
+
+
+def test_omit_event_messages_annotation_omits_message() -> None:
+    adapter: pydantic.TypeAdapter[events.AgentEvent] = pydantic.TypeAdapter(
+        events.OmitEventMessages[events.AgentEvent]
+    )
+    event = events.TextDelta(chunk="hello")
+
+    assert adapter.dump_python(event)["message"] == {"id": "<unset>"}
+    assert b'"message":{"id":"<unset>"}' in adapter.dump_json(event)
+
+
+def test_non_model_events_keep_message() -> None:
+    adapter: pydantic.TypeAdapter[events.AgentEvent] = pydantic.TypeAdapter(
+        events.OmitEventMessages[events.AgentEvent]
+    )
+    tool_message = messages.Message(id="tool-message", role="tool", parts=[])
+    hook_message = messages.Message(
+        id="hook-message", role="internal", parts=[]
+    )
+    source: list[events.AgentEvent] = [
+        events.ToolCallResult(message=tool_message, results=[]),
+        events.HookEvent(
+            message=hook_message,
+            hook=messages.HookPart(
+                hook_id="hook", hook_type="test", status="pending"
+            ),
+        ),
+    ]
+
+    dumped = [adapter.dump_python(event) for event in source]
+
+    assert [item["message"]["id"] for item in dumped] == [
+        "tool-message",
+        "hook-message",
+    ]
+
+
+def test_omitted_model_event_validates_with_dummy_message() -> None:
+    compact: pydantic.TypeAdapter[events.AgentEvent] = pydantic.TypeAdapter(
+        events.OmitEventMessages[events.AgentEvent]
+    )
+    regular: pydantic.TypeAdapter[events.AgentEvent] = pydantic.TypeAdapter(
+        events.AgentEvent
+    )
+
+    event = events.TextDelta(chunk="hello")
+    restored = regular.validate_python(compact.dump_python(event))
+
+    assert isinstance(restored, events.TextDelta)
+    assert restored.message.id == event.message.id
+    assert restored.message.parts == []
 
 
 class TestReplayMessageEvents:


### PR DESCRIPTION
The message is emitted as just `{"id":...}`.

Reduces serialized data by ~97% when serializing messages from a prompt that's asking for about 800 words of output.