### PR TITLE
Make the message hydrator able to restore message ids

### DIFF
--- a/src/ai/models/core/api.py
+++ b/src/ai/models/core/api.py
@@ -115,7 +115,7 @@ class Stream(Generic[StreamOutputT]):
         the concatenated text content unchanged.
         """
         self._gen = gen
-        self._hydrator = types.events._MessageHydrator(seed_message)
+        self._hydrator = types.events.MessageHydrator(seed_message)
         # ``output_type`` is typed against the public ``StreamOutputT`` type
         # param for ergonomics; internally we know it's a Pydantic model
         # subclass (or None for the text-default case).

--- a/src/ai/types/events.py
+++ b/src/ai/types/events.py
@@ -239,20 +239,73 @@ Event = (
 )
 
 
-class _MessageHydrator:
+class MessageHydrator:
+    """Reconstruct messages from a sequential agent event stream."""
+
     def __init__(self, seed_message: messages.Message | None = None) -> None:
+        self._seed_message = seed_message
         self.message = seed_message or messages.Message(
             role="assistant", parts=[]
         )
-        self._parts: dict[str, messages.Part] = {}
+        self.messages = [self.message]
+        self.messages_by_id = {self.message.id: self.message}
+        self._parts_by_message_id: dict[str, dict[str, messages.Part]] = {
+            self.message.id: {}
+        }
+        self._message_selected = seed_message is not None
+        self._seed_checked = False
         # A stream that exhausts without StreamEnd died mid-response.
         self.ended = False
         self.finish_reason: str | None = None
         self.response_id: str | None = None
         self.response_model: str | None = None
 
-    def feed(self, event: Event) -> Event:
+    def feed[T: BaseEvent](self, event: T) -> T:
+        # ToolCallResult and HookEvent always carry full messages, so we just
+        # use them.
+        if isinstance(event, ToolCallResult | HookEvent):
+            self.message = event.message
+            existing = self.messages_by_id.get(event.message.id)
+            if existing is None:
+                self.messages.append(event.message)
+            elif existing is not event.message:
+                self.messages[self.messages.index(existing)] = event.message
+            self.messages_by_id[event.message.id] = event.message
+            return event
+        if not isinstance(event, ModelEvent):
+            return event
+
         updates: dict[str, Any] = {}
+        message_id = event.message.id
+        if message_id != "<unset>":
+            if self._seed_message is not None and not self._seed_checked:
+                self._seed_checked = True
+                if message_id != self.message.id:
+                    raise ValueError(
+                        "seed message id does not match event message id: "
+                        f"{self.message.id!r} != {message_id!r}"
+                    )
+            if message_id != self.message.id:
+                self.ended = False
+                if not self._message_selected:
+                    old_id = self.message.id
+                    del self.messages_by_id[old_id]
+                    self.message.id = message_id
+                    self.messages_by_id[message_id] = self.message
+                    self._parts_by_message_id[message_id] = (
+                        self._parts_by_message_id.pop(old_id)
+                    )
+                    self._message_selected = True
+                else:
+                    self.message = self.messages_by_id.get(
+                        message_id
+                    ) or messages.Message(
+                        id=message_id, role="assistant", parts=[]
+                    )
+                    if message_id not in self.messages_by_id:
+                        self.messages.append(self.message)
+                        self.messages_by_id[message_id] = self.message
+        self._parts = self._parts_by_message_id.setdefault(self.message.id, {})
 
         # Replay events carry no new state — the seeded message already
         # has everything they would have produced.  A replayed turn is

--- a/tests/types/test_events.py
+++ b/tests/types/test_events.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import pydantic
+import pytest
 
 from ai import models
 from ai.types import events, messages
@@ -32,6 +33,201 @@ def test_omit_event_messages_annotation_omits_message() -> None:
 
     assert adapter.dump_python(event)["message"] == {"id": "<unset>"}
     assert b'"message":{"id":"<unset>"}' in adapter.dump_json(event)
+
+
+async def test_message_hydrator_round_trips_replayed_message() -> None:
+    original = messages.Message(
+        id="message-1",
+        role="assistant",
+        parts=[
+            messages.ReasoningPart(
+                id="reasoning-1",
+                text="thinking",
+                provider_metadata={"provider": {"signature": "sig"}},
+            ),
+            messages.TextPart(id="text-1", text="hello world"),
+            messages.ToolCallPart(
+                id="tool-1",
+                tool_call_id="tool-1",
+                tool_name="weather",
+                tool_args='{"city":"SF"}',
+            ),
+            messages.BuiltinToolCallPart(
+                id="builtin-1",
+                tool_call_id="builtin-1",
+                tool_name="web_search",
+                tool_args='{"query":"weather"}',
+            ),
+            messages.BuiltinToolReturnPart(
+                id="builtin-result-1",
+                tool_call_id="builtin-1",
+                tool_name="web_search",
+                result={"temperature": 65},
+            ),
+            messages.FilePart(
+                id="file-1",
+                data="https://example.com/chart.png",
+                media_type="image/png",
+                filename="chart.png",
+            ),
+        ],
+        provider_metadata={"provider": {"response_id": "response-1"}},
+    )
+    originals = [
+        original,
+        messages.Message(
+            id="message-2",
+            role="assistant",
+            parts=[messages.TextPart(id="text-2", text="goodbye")],
+        ),
+    ]
+    compact: pydantic.TypeAdapter[events.Event] = pydantic.TypeAdapter(
+        events.OmitEventMessages[events.Event]
+    )
+    regular: pydantic.TypeAdapter[events.Event] = pydantic.TypeAdapter(
+        events.Event
+    )
+    hydrator = events.MessageHydrator()
+
+    for message in originals:
+        async with models.Stream.replay_message(message) as stream:
+            async for event in stream:
+                dumped = compact.dump_json(event)
+                validated = regular.validate_json(dumped)
+                assert validated.message.id == message.id
+                assert validated.message.parts == []
+                hydrator.feed(validated)
+
+    assert hydrator.message == originals[-1]
+    assert hydrator.messages == originals
+    assert hydrator.messages_by_id == {
+        message.id: message for message in originals
+    }
+
+
+def test_message_hydrator_reconstructs_omitted_messages() -> None:
+    compact: pydantic.TypeAdapter[events.Event] = pydantic.TypeAdapter(
+        events.OmitEventMessages[events.Event]
+    )
+    regular: pydantic.TypeAdapter[events.Event] = pydantic.TypeAdapter(
+        events.Event
+    )
+    message = messages.Message(id="message-1", role="assistant", parts=[])
+    source: list[events.Event] = [
+        events.StreamStart(message=message),
+        events.TextStart(message=message, block_id="text-1"),
+        events.TextDelta(message=message, block_id="text-1", chunk="hello"),
+        events.TextDelta(message=message, block_id="text-1", chunk=" world"),
+        events.TextEnd(message=message, block_id="text-1"),
+        events.StreamEnd(
+            message=message,
+            provider_metadata={"provider": {"id": "1"}},
+        ),
+    ]
+    hydrator = events.MessageHydrator()
+
+    hydrated = [
+        hydrator.feed(regular.validate_json(compact.dump_json(event)))
+        for event in source
+    ]
+
+    assert hydrator.message.id == "message-1"
+    assert hydrator.message.text == "hello world"
+    assert hydrator.message.provider_metadata == {"provider": {"id": "1"}}
+    assert all(
+        isinstance(event, events.ModelEvent)
+        and event.message is hydrator.message
+        for event in hydrated
+    )
+    assert hydrator.ended
+
+
+def test_message_hydrator_selects_message_without_stream_start() -> None:
+    message = messages.Message(id="message", role="assistant", parts=[])
+    hydrator = events.MessageHydrator()
+
+    hydrator.feed(events.TextStart(message=message, block_id="text"))
+    hydrated = hydrator.feed(
+        events.TextDelta(message=message, block_id="text", chunk="hello")
+    )
+
+    assert hydrated.message is hydrator.message
+    assert hydrator.message.id == "message"
+    assert hydrator.message.text == "hello"
+
+
+def test_message_hydrator_rejects_mismatched_seed_id() -> None:
+    hydrator = events.MessageHydrator(
+        messages.Message(id="seed", role="assistant", parts=[])
+    )
+
+    with pytest.raises(ValueError, match=r"seed.*'seed'.*'stream'"):
+        hydrator.feed(
+            events.StreamStart(
+                message=messages.Message(
+                    id="stream", role="assistant", parts=[]
+                )
+            )
+        )
+
+
+def test_message_hydrator_accepts_matching_seed_id() -> None:
+    seed = messages.Message(id="message", role="assistant", parts=[])
+    hydrator = events.MessageHydrator(seed)
+
+    hydrated = hydrator.feed(events.StreamStart(message=seed))
+
+    assert isinstance(hydrated, events.StreamStart)
+    assert hydrated.message is seed
+
+
+def test_message_hydrator_tracks_multiple_messages() -> None:
+    hydrator = events.MessageHydrator()
+    tool_message = messages.Message(id="tool-message", role="tool", parts=[])
+    hook_message = messages.Message(
+        id="hook-message", role="internal", parts=[]
+    )
+    assistant_1 = messages.Message(id="assistant-1", role="assistant", parts=[])
+    assistant_2 = messages.Message(id="assistant-2", role="assistant", parts=[])
+    source: list[events.AgentEvent] = [
+        events.StreamStart(message=assistant_1),
+        events.TextStart(message=assistant_1, block_id="text-1"),
+        events.TextDelta(message=assistant_1, block_id="text-1", chunk="first"),
+        events.StreamEnd(message=assistant_1),
+        events.ToolCallResult(message=tool_message, results=[]),
+        events.HookEvent(
+            message=hook_message,
+            hook=messages.HookPart(
+                hook_id="hook", hook_type="test", status="pending"
+            ),
+        ),
+        events.StreamStart(message=assistant_2),
+        events.TextStart(message=assistant_2, block_id="text-2"),
+        events.TextDelta(
+            message=assistant_2, block_id="text-2", chunk="second"
+        ),
+        events.StreamEnd(message=assistant_2),
+    ]
+
+    hydrated = [hydrator.feed(event) for event in source]
+
+    assert [message.id for message in hydrator.messages] == [
+        "assistant-1",
+        "tool-message",
+        "hook-message",
+        "assistant-2",
+    ]
+    assert list(hydrator.messages_by_id) == [
+        "assistant-1",
+        "tool-message",
+        "hook-message",
+        "assistant-2",
+    ]
+    assert hydrator.messages_by_id["assistant-1"].text == "first"
+    assert hydrator.message is hydrator.messages_by_id["assistant-2"]
+    assert hydrator.message.text == "second"
+    assert hydrated[4] is source[4]
+    assert hydrated[5] is source[5]
 
 
 def test_non_model_events_keep_message() -> None:


### PR DESCRIPTION
And also to handle a stream with multiple messages.

And make it a (semi?)-public API.

We have it stamp the message id onto StreamStart objects so that even if messages are stripped, we can recover the ids by replaying the stream.