### PR TITLE
Support anthropic>=1.0.0 and openai>=3.0.0 (httpx2 change)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,3 +34,40 @@ jobs:
       - run: uv run pytest
 
       - run: uv run examples/.test_scripts/check-examples.py
+
+  provider-sdk-compatibility:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - sdk-versions: minimum
+            openai: openai==2.34.0
+            anthropic: anthropic==0.83.0
+          - sdk-versions: latest
+            openai: openai>=2.34.0,<4.0.0
+            anthropic: anthropic>=0.83.0,<2.0.0
+    name: Provider SDKs (${{ matrix.sdk-versions }})
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - uses: astral-sh/setup-uv@v5
+
+      - run: uv sync
+
+      - name: Install ${{ matrix.sdk-versions }} provider SDKs
+        run: >-
+          uv pip install --upgrade
+          '${{ matrix.openai }}'
+          '${{ matrix.anthropic }}'
+
+      - run: uv run --no-sync mypy src tests
+      - run: uv run --no-sync ty check
+      - run: >-
+          uv run --no-sync pytest
+          tests/providers/openai
+          tests/providers/anthropic

--- a/docs/ai-python/content/docs/basics/providers.mdx
+++ b/docs/ai-python/content/docs/basics/providers.mdx
@@ -61,11 +61,11 @@ model = ai.Model(id="local-model", provider=provider)
 You can pass an upstream client to the provider:
 
 ```python
-import httpx
+import openai
 import ai
 
 
-client = httpx.AsyncClient(timeout=30)
+client = openai.DefaultAsyncHttpxClient(timeout=30)
 provider = ai.get_provider(
     "openai",
     base_url="http://localhost:1234/v1",
@@ -73,6 +73,18 @@ provider = ai.get_provider(
     client=client,
 )
 model = ai.Model(id="local-model", provider=provider)
+```
+
+Anthropic exposes the equivalent client:
+
+```python
+import anthropic
+import ai
+
+
+client = anthropic.DefaultAsyncHttpxClient(timeout=30)
+provider = ai.get_provider("anthropic", client=client)
+model = ai.Model(id="claude-sonnet-4-6", provider=provider)
 ```
 
 Close explicit providers when your app shuts down:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,9 +34,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-anthropic = ["anthropic>=0.83.0"]
+anthropic = ["anthropic>=0.83.0,<2.0.0"]
 mcp = ["mcp>=1.18.0"]
-openai = ["openai>=2.14.0"]
+openai = ["openai>=2.34.0,<4.0.0"]
 otel = [
     "opentelemetry-exporter-otlp-proto-http>=1.30",
     "opentelemetry-sdk>=1.30",

--- a/src/ai/providers/anthropic/errors.py
+++ b/src/ai/providers/anthropic/errors.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, cast
 
-import httpx
-
 from ... import errors as ai_errors
 from . import _sdk
 
@@ -131,8 +129,8 @@ def _http_context(
     response = getattr(exc, "response", None)
     return ai_errors.HTTPErrorContext(
         status_code=status_code,
-        request=request if isinstance(request, httpx.Request) else None,
-        response=response if isinstance(response, httpx.Response) else None,
+        request=request,
+        response=response,
     )
 
 

--- a/src/ai/providers/anthropic/provider.py
+++ b/src/ai/providers/anthropic/provider.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, ClassVar, Literal
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, cast
 
-import httpx
 import pydantic
 
 from ... import errors as ai_errors
@@ -26,10 +25,14 @@ if TYPE_CHECKING:
     from ...types import messages as messages_
     from ...types import tools as tools_
 
-    AnthropicClient = httpx.AsyncClient | anthropic.AsyncAnthropic
+    AnthropicClient = (
+        anthropic.DefaultAsyncHttpxClient | anthropic.AsyncAnthropic
+    )
+    AnthropicHTTPClient = anthropic.DefaultAsyncHttpxClient
     AnthropicSDKClient = anthropic.AsyncAnthropic
 else:
     AnthropicClient = Any
+    AnthropicHTTPClient = Any
     AnthropicSDKClient = Any
 
 _BASE_URL = "https://api.anthropic.com"
@@ -46,7 +49,9 @@ class AnthropicCompatibleProvider(base.Provider[AnthropicSDKClient]):
     provider_class_id: Literal["anthropic-compatible"] = "anthropic-compatible"
     anthropic_version: str = _ANTHROPIC_VERSION
 
-    _http_client: httpx.AsyncClient | None = pydantic.PrivateAttr(default=None)
+    _http_client: AnthropicHTTPClient | None = pydantic.PrivateAttr(
+        default=None
+    )
     _close_client_on_aclose: bool = pydantic.PrivateAttr(default=False)
     _has_user_sdk_client: bool = pydantic.PrivateAttr(default=False)
 
@@ -54,36 +59,24 @@ class AnthropicCompatibleProvider(base.Provider[AnthropicSDKClient]):
         self._close_client_on_aclose = True
 
     def _set_runtime_client(self, client: AnthropicClient | None) -> None:
-        anthropic_sdk = None
-        if client is not None and not isinstance(client, httpx.AsyncClient):
-            anthropic_sdk = _sdk.import_sdk(provider=self.name)
-
+        anthropic_sdk = (
+            _sdk.import_sdk(provider=self.name) if client is not None else None
+        )
         if anthropic_sdk is not None and isinstance(
             client, anthropic_sdk.AsyncAnthropic
         ):
-            sdk_client = client
-            http_client = None
             self._has_user_sdk_client = True
             self._close_client_on_aclose = False
-        elif isinstance(client, httpx.AsyncClient) or client is None:
-            sdk_client = None
-            http_client = client
+            self._set_client(client)
+        else:
+            self._http_client = cast("AnthropicHTTPClient | None", client)
             self._has_user_sdk_client = False
             self._close_client_on_aclose = client is None
-        else:
-            raise TypeError(
-                "Anthropic providers require an httpx.AsyncClient or "
-                "anthropic.AsyncAnthropic"
-            )
-
-        self._http_client = http_client
-        if sdk_client is not None:
-            self._set_client(sdk_client)
 
     def _make_sdk_client(
         self,
         *,
-        http_client: httpx.AsyncClient | None = None,
+        http_client: AnthropicHTTPClient | None = None,
     ) -> AnthropicSDKClient:
         anthropic_sdk = _sdk.import_sdk(provider=self.name)
         return anthropic_sdk.AsyncAnthropic(

--- a/src/ai/providers/openai/errors.py
+++ b/src/ai/providers/openai/errors.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-import httpx
-
 from ... import errors as ai_errors
 from . import _sdk
 
@@ -142,8 +140,8 @@ def _http_context(exc: openai.OpenAIError) -> ai_errors.HTTPErrorContext | None:
     response = getattr(exc, "response", None)
     return ai_errors.HTTPErrorContext(
         status_code=status_code,
-        request=request if isinstance(request, httpx.Request) else None,
-        response=response if isinstance(response, httpx.Response) else None,
+        request=request,
+        response=response,
     )
 
 

--- a/src/ai/providers/openai/provider.py
+++ b/src/ai/providers/openai/provider.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, ClassVar, Literal
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, cast
 
-import httpx
 import pydantic
 
 from ... import errors as ai_errors
@@ -26,10 +25,12 @@ if TYPE_CHECKING:
     from ...types import messages as messages_
     from ...types import tools as tools_
 
-    OpenAIClient = httpx.AsyncClient | openai.AsyncOpenAI
+    OpenAIClient = openai.DefaultAsyncHttpxClient | openai.AsyncOpenAI
+    OpenAIHTTPClient = openai.DefaultAsyncHttpxClient
     OpenAISDKClient = openai.AsyncOpenAI
 else:
     OpenAIClient = Any
+    OpenAIHTTPClient = Any
     OpenAISDKClient = Any
 
 _BASE_URL = "https://api.openai.com/v1"
@@ -48,7 +49,7 @@ class OpenAICompatibleProvider(base.Provider[OpenAISDKClient]):
 
     provider_class_id: Literal["openai-compatible"] = "openai-compatible"
 
-    _http_client: httpx.AsyncClient | None = pydantic.PrivateAttr(default=None)
+    _http_client: OpenAIHTTPClient | None = pydantic.PrivateAttr(default=None)
     _close_client_on_aclose: bool = pydantic.PrivateAttr(default=False)
     _has_user_sdk_client: bool = pydantic.PrivateAttr(default=False)
 
@@ -56,36 +57,24 @@ class OpenAICompatibleProvider(base.Provider[OpenAISDKClient]):
         self._close_client_on_aclose = True
 
     def _set_runtime_client(self, client: OpenAIClient | None) -> None:
-        openai_sdk = None
-        if client is not None and not isinstance(client, httpx.AsyncClient):
-            openai_sdk = _sdk.import_sdk(provider=self.name)
-
+        openai_sdk = (
+            _sdk.import_sdk(provider=self.name) if client is not None else None
+        )
         if openai_sdk is not None and isinstance(
             client, openai_sdk.AsyncOpenAI
         ):
-            sdk_client = client
-            http_client = None
             self._has_user_sdk_client = True
             self._close_client_on_aclose = False
-        elif isinstance(client, httpx.AsyncClient) or client is None:
-            sdk_client = None
-            http_client = client
+            self._set_client(client)
+        else:
+            self._http_client = cast("OpenAIHTTPClient | None", client)
             self._has_user_sdk_client = False
             self._close_client_on_aclose = client is None
-        else:
-            raise TypeError(
-                "OpenAI providers require an httpx.AsyncClient or "
-                "openai.AsyncOpenAI"
-            )
-
-        self._http_client = http_client
-        if sdk_client is not None:
-            self._set_client(sdk_client)
 
     def _make_sdk_client(
         self,
         *,
-        http_client: httpx.AsyncClient | None = None,
+        http_client: OpenAIHTTPClient | None = None,
     ) -> OpenAISDKClient:
         openai_sdk = _sdk.import_sdk(provider=self.name)
         return openai_sdk.AsyncOpenAI(

--- a/tests/providers/anthropic/test_adapter.py
+++ b/tests/providers/anthropic/test_adapter.py
@@ -6,10 +6,10 @@ of provider-executed tool parts.
 
 from __future__ import annotations
 
+import importlib
 from typing import Any, cast
 
 import anthropic
-import httpx
 import pytest
 
 import ai
@@ -17,6 +17,10 @@ from ai.providers.anthropic import protocol
 from ai.types import messages
 
 from .conftest import FakeAnthropicClient
+
+httpx = importlib.import_module(
+    "httpx2" if int(anthropic.__version__.partition(".")[0]) >= 1 else "httpx"
+)
 
 
 class _RaisingMessages:

--- a/tests/providers/anthropic/test_probe.py
+++ b/tests/providers/anthropic/test_probe.py
@@ -7,14 +7,19 @@ provider-specific 200 path so we know URL routing is wired up.
 
 from __future__ import annotations
 
+import importlib
 import json
 from typing import Any
 
-import httpx
+import anthropic
 import pytest
 
 import ai
 from ai.providers.anthropic import AnthropicCompatibleProvider
+
+httpx = importlib.import_module(
+    "httpx2" if int(anthropic.__version__.partition(".")[0]) >= 1 else "httpx"
+)
 
 
 def _client_with_mock(
@@ -22,7 +27,7 @@ def _client_with_mock(
     json_body: Any = None,
     base_url: str = "https://anthropic.test",
 ) -> ai.Model:
-    def _handler(request: httpx.Request) -> httpx.Response:
+    def _handler(request: Any) -> Any:
         body = json.dumps(json_body or {}).encode()
         return httpx.Response(status_code, content=body)
 
@@ -54,7 +59,7 @@ async def test_model_not_found_raises_model_not_found() -> None:
 async def test_custom_anthropic_version_header() -> None:
     captured_headers: dict[str, str] = {}
 
-    def _handler(request: httpx.Request) -> httpx.Response:
+    def _handler(request: Any) -> Any:
         captured_headers.update(dict(request.headers))
         body = json.dumps({"id": "custom-model", "type": "model"}).encode()
         return httpx.Response(200, content=body)

--- a/tests/providers/anthropic/test_provider.py
+++ b/tests/providers/anthropic/test_provider.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import importlib
+from typing import Any
 
 import anthropic
-import httpx
 import pytest
 
 import ai
@@ -12,12 +12,16 @@ from ai.providers.anthropic import (
     AnthropicMessagesProtocol,
 )
 
+httpx = importlib.import_module(
+    "httpx2" if int(anthropic.__version__.partition(".")[0]) >= 1 else "httpx"
+)
+
 
 async def test_list_models_gets_provider_headers_and_sorts_ids() -> None:
     captured_urls: list[str] = []
     captured_headers: dict[str, str] = {}
 
-    def _handler(request: httpx.Request) -> httpx.Response:
+    def _handler(request: Any) -> Any:
         captured_urls.append(str(request.url))
         captured_headers.update(dict(request.headers))
         return httpx.Response(
@@ -51,7 +55,7 @@ async def test_list_models_gets_provider_headers_and_sorts_ids() -> None:
 
 
 async def test_list_models_maps_sdk_errors_to_provider_hierarchy() -> None:
-    def _handler(request: httpx.Request) -> httpx.Response:
+    def _handler(request: Any) -> Any:
         return httpx.Response(
             529,
             json={
@@ -86,7 +90,7 @@ async def test_list_models_maps_sdk_errors_to_provider_hierarchy() -> None:
 
 
 async def test_list_models_404_stays_generic_not_found() -> None:
-    def _handler(request: httpx.Request) -> httpx.Response:
+    def _handler(request: Any) -> Any:
         return httpx.Response(404, json={"error": {"message": "missing"}})
 
     provider = ai.get_provider(

--- a/tests/providers/openai/test_adapter.py
+++ b/tests/providers/openai/test_adapter.py
@@ -6,10 +6,10 @@ formatting, and explicit guards against unsupported built-in tool surfaces.
 
 from __future__ import annotations
 
+import importlib
 from types import SimpleNamespace
 from typing import Any, cast
 
-import httpx
 import openai
 import pydantic
 import pytest
@@ -19,6 +19,10 @@ from ai.providers.openai import params as openai_params
 from ai.providers.openai import protocol
 from ai.providers.openai import tools as openai_tools
 from ai.types import events, messages, tools
+
+httpx = importlib.import_module(
+    "httpx2" if int(openai.__version__.partition(".")[0]) >= 3 else "httpx"
+)
 
 
 class _Answer(pydantic.BaseModel):

--- a/tests/providers/openai/test_probe.py
+++ b/tests/providers/openai/test_probe.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
+import importlib
 import json
 from typing import Any
 
-import httpx
+import openai
 import pytest
 
 import ai
+
+httpx = importlib.import_module(
+    "httpx2" if int(openai.__version__.partition(".")[0]) >= 3 else "httpx"
+)
 
 
 def _client_with_mock(
@@ -14,7 +19,7 @@ def _client_with_mock(
     json_body: Any = None,
     base_url: str = "https://openai.test/v1",
 ) -> ai.Model:
-    def _handler(request: httpx.Request) -> httpx.Response:
+    def _handler(request: Any) -> Any:
         body = json.dumps(json_body or {}).encode()
         return httpx.Response(status_code, content=body)
 

--- a/tests/providers/openai/test_provider.py
+++ b/tests/providers/openai/test_provider.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import importlib
+from typing import Any
 
-import httpx
 import openai
 import pytest
 
@@ -12,12 +12,16 @@ from ai.providers.openai import (
     OpenAIResponsesProtocol,
 )
 
+httpx = importlib.import_module(
+    "httpx2" if int(openai.__version__.partition(".")[0]) >= 3 else "httpx"
+)
+
 
 async def test_list_models_gets_models_with_auth_header_and_sorts_ids() -> None:
     captured_urls: list[str] = []
     captured_headers: dict[str, str] = {}
 
-    def _handler(request: httpx.Request) -> httpx.Response:
+    def _handler(request: Any) -> Any:
         captured_urls.append(str(request.url))
         captured_headers.update(dict(request.headers))
         return httpx.Response(
@@ -50,7 +54,7 @@ async def test_list_models_gets_models_with_auth_header_and_sorts_ids() -> None:
 
 
 async def test_list_models_maps_sdk_errors_to_provider_hierarchy() -> None:
-    def _handler(request: httpx.Request) -> httpx.Response:
+    def _handler(request: Any) -> Any:
         return httpx.Response(
             429,
             json={
@@ -91,7 +95,7 @@ async def test_list_models_maps_sdk_errors_to_provider_hierarchy() -> None:
 
 
 async def test_list_models_404_stays_generic_not_found() -> None:
-    def _handler(request: httpx.Request) -> httpx.Response:
+    def _handler(request: Any) -> Any:
         return httpx.Response(404, json={"error": {"message": "missing"}})
 
     provider = ai.get_provider(

--- a/uv.lock
+++ b/uv.lock
@@ -58,11 +58,11 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.83.0" },
+    { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.83.0,<2.0.0" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.18.0" },
     { name = "modelsdotdev", specifier = "==0.*" },
-    { name = "openai", marker = "extra == 'openai'", specifier = ">=2.14.0" },
+    { name = "openai", marker = "extra == 'openai'", specifier = ">=2.34.0,<4.0.0" },
     { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'otel'", specifier = ">=1.30" },
     { name = "opentelemetry-sdk", marker = "extra == 'otel'", specifier = ">=1.30" },
     { name = "pydantic", specifier = ">=2.13" },


### PR DESCRIPTION
Stop doing our own runtime enforcement of the client objects for anthropic and openai, just pass them through and see what they allow. (anthropic will only allow httpx2, openai has compat goo to allow both.)

Bump the minimum version of openai to 2.34.0, because it turned out that was already the case.

Add CI to test different upstream SDK versions.
(Though it is still all a bit marginal because we don't actually make any requests in CI!)